### PR TITLE
Add chip component

### DIFF
--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Chip from './Chip';
+
+export default {
+  title: 'Chip',
+  component: Chip,
+  argTypes: {
+    label: { control: 'text' },
+  },
+} as ComponentMeta<typeof Chip>;
+
+const Template: ComponentStory<typeof Chip> = (args) => <Chip {...args} />;
+
+export const Regular = Template.bind({});
+Regular.args = {
+  label: 'Tag 1',
+};
+
+export const RowOfTags = Template.bind({});
+RowOfTags.argTypes = {
+  label: { control: { disable: true } },
+};
+
+RowOfTags.decorators = [
+  () => (
+    <div className="space-x-1">
+      <Chip {...(RowOfTags.args, { label: 'Tag 1' })} />
+      <Chip {...(RowOfTags.args, { label: 'Another tag' })} />
+      <Chip {...(RowOfTags.args, { label: 'Third tag' })} />
+    </div>
+  ),
+];

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,0 +1,13 @@
+interface ChipProps {
+  label: string;
+}
+
+const Chip = ({ label }: ChipProps) => {
+  return <span className="text-[#1B2232] bg-[#EDF2F7] px-3 py-1 rounded-full text-xs">{label}</span>;
+};
+
+Chip.componentProps = {
+  label: String,
+};
+
+export default Chip;


### PR DESCRIPTION
This PR adds the `Chip` component to the project, which will be used in the `Row component`. Additionally, the Storybook stories have been modified to include the Chip component.

The stories for the Chip component include:
- Regular: A chip with the label set to "Tag 1"
- Row of tags: Three chips displayed horizontally in the same div

These stories will help us visualise and test the Chip component.

**Screenshot**:


| Regular | Row of tags |
|---------|-------------|
|     ![Chip component](https://user-images.githubusercontent.com/52673485/225093213-c18de206-05c9-4ef3-8948-2b2cfbfc1d13.png)    |       ![Row of tags](https://user-images.githubusercontent.com/52673485/225093947-67774082-1df8-47de-8bd8-7f564b05af75.png)      |


