### PR TITLE
Add "Details Tabs" Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nofrixion/web-components",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nofrixion/web-components",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@headlessui/react": "1.6.0",
         "@radix-ui/react-checkbox": "^1.0.3",

--- a/src/components/ui/DetailsTabs/DetailsTabs.stories.tsx
+++ b/src/components/ui/DetailsTabs/DetailsTabs.stories.tsx
@@ -1,0 +1,13 @@
+import { Meta, StoryFn } from '@storybook/react';
+import DetailsTabs from './DetailsTabs';
+
+export default {
+  title: 'UI/Details Tabs',
+  component: DetailsTabs,
+} as Meta<typeof DetailsTabs>;
+
+const Template: StoryFn<typeof DetailsTabs> = (args) => <DetailsTabs {...args} />;
+
+export const Showcase = Template.bind({});
+
+Showcase.args = {};

--- a/src/components/ui/DetailsTabs/DetailsTabs.tsx
+++ b/src/components/ui/DetailsTabs/DetailsTabs.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import * as Tabs from '@radix-ui/react-tabs';
+import { AnimatePresence, MotionConfig, motion } from 'framer-motion';
+import classNames from 'classnames';
+
+const tabs = ['History', 'Payment info'];
+
+interface TabProps {
+  value: string;
+  selectedTab: string;
+  children: React.ReactNode;
+}
+
+const TabContent: React.FC<TabProps> = ({ value, selectedTab, children }) => {
+  return (
+    <AnimatePresence>
+      <Tabs.Content asChild value={value}>
+        <motion.div
+          key={selectedTab}
+          initial={{ y: 10, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: -10, opacity: 0 }}
+        >
+          {children}
+        </motion.div>
+      </Tabs.Content>
+    </AnimatePresence>
+  );
+};
+
+// Get type of classnames
+const underlineClasses = 'w-full h-px absolute bottom-0';
+
+const DetailsTabs: React.FC<{}> = ({}) => {
+  const [selectedTab, setSelectedTab] = useState(tabs[0]);
+
+  return (
+    <MotionConfig transition={{ ease: 'easeInOut' }}>
+      <Tabs.Root value={selectedTab} onValueChange={setSelectedTab}>
+        <Tabs.List className="flex mb-11" aria-label="Explore Payment Request Details">
+          {tabs.map((tab) => {
+            return (
+              <Tabs.Trigger
+                key={tab}
+                className="relative w-full h-10 select-none text-sm/6 text-greyText transition hover:text-defaultText data-[state=active]:text-defaultText"
+                value={tab}
+              >
+                {tab}
+
+                {selectedTab == tab ? (
+                  <motion.div layoutId="underline" className={classNames(underlineClasses, 'bg-primaryGreen z-10')} />
+                ) : (
+                  <div className={classNames(underlineClasses, 'bg-borderGrey')} />
+                )}
+
+                {/* 
+                  Underline for when the animation is happening
+                  so that the underline doesn't disappear
+                */}
+                <div className={classNames(underlineClasses, 'bg-borderGrey')} />
+              </Tabs.Trigger>
+            );
+          })}
+        </Tabs.List>
+        <TabContent value={tabs[0]} selectedTab={selectedTab}>
+          {/* TODO: Replace with Transactions history component */}
+          <div className="h-80 bg-blue-200" />
+        </TabContent>
+        <TabContent value={tabs[1]} selectedTab={selectedTab}>
+          {/* TODO: Replace with Payment info component */}
+          <div className="h-80 bg-yellow-200" />
+        </TabContent>
+      </Tabs.Root>
+    </MotionConfig>
+  );
+};
+
+export default DetailsTabs;


### PR DESCRIPTION
This pull request introduces the "Details Tabs" component which is destined for use in the Payment Request Details modal.

Please note that this PR only includes the Tabs component itself; the content of each tab will be developed in separate tickets (in the meantime, coloured boxes where added as placeholders).

Two subtle animations have been added for enhanced user experience:

- The green underline beneath the tab titles smoothly transitions its position when switching tabs.
- The content within each tab appears with a slight opacity and subtly slides in from bottom to top. These animations are deliberately subtle to avoid distracting the user.

A video demonstrating these animations and behaviour has been attached to this PR for reference.

https://github.com/nofrixion/nofrixion.webcomponents/assets/52673485/b535a6f9-7495-4dce-9016-6f4dd5a3cfbe