### PR TITLE
[MOOV-1773]: Fixed extra API calls caused by reference comparison

### DIFF
--- a/src/api/hooks/usePaymentRequestMetrics.ts
+++ b/src/api/hooks/usePaymentRequestMetrics.ts
@@ -6,8 +6,8 @@ export const usePaymentRequestMetrics = (
   apiUrl: string,
   authToken: string,
   merchantId: string,
-  fromDate?: Date,
-  toDate?: Date,
+  fromDateMs?: number,
+  toDateMs?: number,
 ) => {
   const [metrics, setMetrics] = useState<PaymentRequestMetrics>();
   const [apiError, setApiError] = useState<ApiError>();
@@ -15,7 +15,7 @@ export const usePaymentRequestMetrics = (
   useEffect(() => {
     const fetchPaymentRequestMetrics = async () => {
       const client = new PaymentRequestClient(apiUrl, authToken, merchantId);
-      const response = await client.metrics(fromDate, toDate);
+      const response = await client.metrics(new Date(fromDateMs ?? 0), new Date(toDateMs ?? 0));
 
       if (response.data) {
         setMetrics(response.data);
@@ -25,7 +25,7 @@ export const usePaymentRequestMetrics = (
     };
 
     fetchPaymentRequestMetrics();
-  }, [apiUrl, authToken, merchantId, fromDate, toDate]);
+  }, [apiUrl, authToken, merchantId, fromDateMs, toDateMs]);
 
   return {
     metrics,

--- a/src/api/hooks/usePaymentRequests.ts
+++ b/src/api/hooks/usePaymentRequests.ts
@@ -15,8 +15,8 @@ export const usePaymentRequests = (
   amountSortDirection: SortDirection,
   page: number,
   pageSize?: number,
-  fromDate?: Date,
-  toDate?: Date,
+  fromDateMs?: number,
+  toDateMs?: number,
   status?: PaymentRequestStatus,
 ) => {
   const client = new MoneyMoovApiClient(apiUrl, authToken, merchantId);
@@ -27,7 +27,14 @@ export const usePaymentRequests = (
   const [apiError, setApiError] = useState<ApiError>();
 
   const fetchPaymentRequests = async () => {
-    const response = await client.PaymentRequests.getAll(page, pageSize, sortExpression, fromDate, toDate, status);
+    const response = await client.PaymentRequests.getAll(
+      page,
+      pageSize,
+      sortExpression,
+      new Date(fromDateMs ?? 0),
+      new Date(toDateMs ?? 0),
+      status,
+    );
 
     if (response.data) {
       setPaymentRequests(response.data.content);
@@ -58,8 +65,8 @@ export const usePaymentRequests = (
     createdSortDirection,
     contactSortDirection,
     amountSortDirection,
-    fromDate,
-    toDate,
+    fromDateMs,
+    toDateMs,
     status,
   ]);
 

--- a/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -14,7 +14,7 @@ import { makeToast } from '../../ui/Toast/Toast';
 import { RemotePaymentRequestToLocalPaymentRequest } from '../../../utils/parsers';
 import classNames from 'classnames';
 import CreatePaymentRequestPage from '../../functional/CreatePaymentRequestPage/CreatePaymentRequestPage';
-import { add, startOfDay } from 'date-fns';
+import { add, startOfDay, endOfDay } from 'date-fns';
 
 interface PaymentRequestDashboardProps {
   token: string; // Example: "eyJhbGciOiJIUz..."
@@ -36,7 +36,7 @@ const PaymentRequestDashboard = ({
   const [status, setStatus] = useState<PaymentRequestStatus>(PaymentRequestStatus.All);
   const [dateRange, setDateRange] = useState<DateRange>({
     fromDate: startOfDay(add(new Date(), { days: -90 })), // Last 90 days as default
-    toDate: new Date(),
+    toDate: endOfDay(new Date()),
   });
 
   let [isCreatePaymentRequestOpen, setIsCreatePaymentRequestOpen] = useState(false);
@@ -70,8 +70,8 @@ const PaymentRequestDashboard = ({
     amountSortDirection,
     page,
     pageSize,
-    dateRange.fromDate,
-    dateRange.toDate,
+    dateRange.fromDate.getTime(),
+    dateRange.toDate.getTime(),
     status,
   );
 
@@ -83,8 +83,8 @@ const PaymentRequestDashboard = ({
     apiUrl,
     token,
     merchantId,
-    dateRange.fromDate,
-    dateRange.toDate,
+    dateRange.fromDate.getTime(),
+    dateRange.toDate.getTime(),
   );
 
   const onDeletePaymentRequest = async (paymentRequest: LocalPaymentRequest) => {


### PR DESCRIPTION
Metrics and PaymentRequests endpoints were being called twice. That was because the hooks that invoked them were being executed twice because of the Date parameters.

The Date parameters were reworked into number (milliseconds) parameters, and there was a mismatch between the endDateRange default value and the DateRange component default endDateRange value.