### PR TITLE
Implement New Status Filter Design for Payment Requests (ex Tabs)

### DIFF
--- a/src/api/hooks/usePaymentRequestMetrics.ts
+++ b/src/api/hooks/usePaymentRequestMetrics.ts
@@ -11,9 +11,11 @@ export const usePaymentRequestMetrics = (
 ) => {
   const [metrics, setMetrics] = useState<PaymentRequestMetrics>();
   const [apiError, setApiError] = useState<ApiError>();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchPaymentRequestMetrics = async () => {
+      setIsLoading(true);
       const client = new PaymentRequestClient(apiUrl, authToken, merchantId);
       const response = await client.metrics(new Date(fromDateMs ?? 0), new Date(toDateMs ?? 0));
 
@@ -22,6 +24,7 @@ export const usePaymentRequestMetrics = (
       } else if (response.error) {
         setApiError(response.error);
       }
+      setIsLoading(false);
     };
 
     fetchPaymentRequestMetrics();
@@ -30,5 +33,6 @@ export const usePaymentRequestMetrics = (
   return {
     metrics,
     apiError,
+    isLoading,
   };
 };

--- a/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -32,7 +32,7 @@ const PaymentRequestDashboard = ({
   const [createdSortDirection, setCreatedSortDirection] = useState<SortDirection>(SortDirection.NONE);
   const [contactSortDirection, setContactSortDirection] = useState<SortDirection>(SortDirection.NONE);
   const [amountSortDirection, setAmountSortDirection] = useState<SortDirection>(SortDirection.NONE);
-  const [selectedTab, setSelectedTab] = useState('allTab');
+  const [selectedTab, setSelectedTab] = useState(PaymentRequestStatus.All);
   const [status, setStatus] = useState<PaymentRequestStatus>(PaymentRequestStatus.All);
   const [dateRange, setDateRange] = useState<DateRange>({
     fromDate: startOfDay(add(new Date(), { days: -90 })), // Last 90 days as default
@@ -40,18 +40,6 @@ const PaymentRequestDashboard = ({
   });
 
   let [isCreatePaymentRequestOpen, setIsCreatePaymentRequestOpen] = useState(false);
-
-  const tabsTriggerClassNames = (status: PaymentRequestStatus) => {
-    return classNames(
-      "text-greyText hover:text-defaultText hover:bg-[#F0F2F5] hover:cursor-pointer pt-0 h-20 transition data-[state='active']:text-defaultText data-[state='active']:bg-white data-[state='active']:cursor-default data-[disabled]:pointer-events-none data-[disabled]:cursor-not-allowed focus:relative",
-      {
-        "data-[state='active']:shadow-[inset_0_2px_0px_#00B2B2]": status === PaymentRequestStatus.All,
-        "data-[state='active']:shadow-[inset_0_2px_0px_#E88C30]": status === PaymentRequestStatus.PartiallyPaid,
-        "data-[state='active']:shadow-[inset_0_2px_0px_#ABB2BA]": status === PaymentRequestStatus.None,
-        "data-[state='active']:shadow-[inset_0_2px_0px_#00CC88]": status === PaymentRequestStatus.FullyPaid,
-      },
-    );
-  };
 
   const tabsContentClasses = 'bg-white p-6 h-full';
 
@@ -74,7 +62,6 @@ const PaymentRequestDashboard = ({
     dateRange.toDate.getTime(),
     status,
   );
-  console.log('isLoading', isLoading);
 
   const localPaymentRequests: LocalPaymentRequest[] =
     paymentRequests?.map((paymentRequest) => RemotePaymentRequestToLocalPaymentRequest(paymentRequest)) ?? [];
@@ -129,23 +116,6 @@ const PaymentRequestDashboard = ({
     await fetchPaymentRequests();
   };
 
-  useEffect(() => {
-    switch (selectedTab) {
-      case 'allTab':
-        setStatus(PaymentRequestStatus.All);
-        break;
-      case 'unpaidTab':
-        setStatus(PaymentRequestStatus.None);
-        break;
-      case 'partiallyPaidTab':
-        setStatus(PaymentRequestStatus.PartiallyPaid);
-        break;
-      case 'paidTab':
-        setStatus(PaymentRequestStatus.FullyPaid);
-        break;
-    }
-  }, [selectedTab]);
-
   return (
     <div className="font-inter bg-mainGrey text-defaultText h-full pl-8 pr-8 pb-10">
       <div className="flex justify-between">
@@ -176,97 +146,35 @@ const PaymentRequestDashboard = ({
       </div>
 
       <div className="h-full">
-        <Tabs.Root defaultValue="allTab" onValueChange={(value) => setSelectedTab(value)}>
-          <Tabs.List className="flex shrink-0">
-            <Tabs.Trigger className={tabsTriggerClassNames(status)} value="allTab" disabled={metrics?.all === 0}>
-              <Tab status={PaymentRequestStatus.All} totalRecords={metrics?.all ?? 0}></Tab>
-            </Tabs.Trigger>
-            <Tabs.Trigger className={tabsTriggerClassNames(status)} value="unpaidTab" disabled={metrics?.unpaid === 0}>
-              <Tab status={PaymentRequestStatus.None} totalRecords={metrics?.unpaid ?? 0}></Tab>
-            </Tabs.Trigger>
-            <Tabs.Trigger
-              className={tabsTriggerClassNames(status)}
-              value="partiallyPaidTab"
-              disabled={metrics?.partiallyPaid === 0}
-            >
-              <Tab status={PaymentRequestStatus.PartiallyPaid} totalRecords={metrics?.partiallyPaid ?? 0}></Tab>
-            </Tabs.Trigger>
-            <Tabs.Trigger className={tabsTriggerClassNames(status)} value="paidTab" disabled={metrics?.paid === 0}>
-              <Tab status={PaymentRequestStatus.FullyPaid} totalRecords={metrics?.paid ?? 0}></Tab>
-            </Tabs.Trigger>
+        <Tabs.Root
+          defaultValue={PaymentRequestStatus.All}
+          onValueChange={(value) => setStatus(value as PaymentRequestStatus)}
+        >
+          {/* Keep the Tab to still get accessibility functions through the keyboard */}
+          <Tabs.List className="flex shrink-0 gap-x-4 mb-4">
+            <Tab status={PaymentRequestStatus.All} totalRecords={metrics?.all ?? 0}></Tab>
+            <Tab status={PaymentRequestStatus.None} totalRecords={metrics?.unpaid ?? 0}></Tab>
+            <Tab status={PaymentRequestStatus.PartiallyPaid} totalRecords={metrics?.partiallyPaid ?? 0}></Tab>
+            <Tab status={PaymentRequestStatus.FullyPaid} totalRecords={metrics?.paid ?? 0}></Tab>
           </Tabs.List>
-          <Tabs.Content className={tabsContentClasses} value="allTab">
-            <div className="min-h-[18rem]">
-              <PaymentRequestTable
-                paymentRequests={localPaymentRequests}
-                pageSize={pageSize}
-                totalRecords={totalRecords}
-                onPageChanged={setPage}
-                setStatusSortDirection={setStatusSortDirection}
-                setCreatedSortDirection={setCreatedSortDirection}
-                setContactSortDirection={setContactSortDirection}
-                setAmountSortDirection={setAmountSortDirection}
-                onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
-                onPaymentRequestDeleteClicked={onDeletePaymentRequest}
-                onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
-                isLoading={isLoading}
-              />
-            </div>
-          </Tabs.Content>
-          <Tabs.Content className={tabsContentClasses} value="unpaidTab">
-            <div>
-              <PaymentRequestTable
-                paymentRequests={localPaymentRequests}
-                pageSize={pageSize}
-                totalRecords={totalRecords}
-                onPageChanged={setPage}
-                setStatusSortDirection={setStatusSortDirection}
-                setCreatedSortDirection={setCreatedSortDirection}
-                setContactSortDirection={setContactSortDirection}
-                setAmountSortDirection={setAmountSortDirection}
-                onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
-                onPaymentRequestDeleteClicked={onDeletePaymentRequest}
-                onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
-                isLoading={isLoading}
-              />
-            </div>
-          </Tabs.Content>
-          <Tabs.Content className={tabsContentClasses} value="partiallyPaidTab">
-            <div>
-              <PaymentRequestTable
-                paymentRequests={localPaymentRequests}
-                pageSize={pageSize}
-                totalRecords={totalRecords}
-                onPageChanged={setPage}
-                setStatusSortDirection={setStatusSortDirection}
-                setCreatedSortDirection={setCreatedSortDirection}
-                setContactSortDirection={setContactSortDirection}
-                setAmountSortDirection={setAmountSortDirection}
-                onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
-                onPaymentRequestDeleteClicked={onDeletePaymentRequest}
-                onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
-                isLoading={isLoading}
-              />
-            </div>
-          </Tabs.Content>
-          <Tabs.Content className={tabsContentClasses} value="paidTab">
-            <div>
-              <PaymentRequestTable
-                paymentRequests={localPaymentRequests}
-                pageSize={pageSize}
-                totalRecords={totalRecords}
-                onPageChanged={setPage}
-                setStatusSortDirection={setStatusSortDirection}
-                setCreatedSortDirection={setCreatedSortDirection}
-                setContactSortDirection={setContactSortDirection}
-                setAmountSortDirection={setAmountSortDirection}
-                onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
-                onPaymentRequestDeleteClicked={onDeletePaymentRequest}
-                onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
-                isLoading={isLoading}
-              />
-            </div>
-          </Tabs.Content>
+          <Tabs.Content value=""></Tabs.Content>
+
+          <div className="bg-white min-h-[18rem] py-10 px-6 rounded-lg">
+            <PaymentRequestTable
+              paymentRequests={localPaymentRequests}
+              pageSize={pageSize}
+              totalRecords={totalRecords}
+              onPageChanged={setPage}
+              setStatusSortDirection={setStatusSortDirection}
+              setCreatedSortDirection={setCreatedSortDirection}
+              setContactSortDirection={setContactSortDirection}
+              setAmountSortDirection={setAmountSortDirection}
+              onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
+              onPaymentRequestDeleteClicked={onDeletePaymentRequest}
+              onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
+              isLoading={isLoading}
+            />
+          </div>
         </Tabs.Root>
       </div>
 

--- a/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -1,7 +1,7 @@
 import { PaymentRequestStatus } from '../../../api/types/Enums';
 import Tab from '../../ui/Tab/Tab';
 import * as Tabs from '@radix-ui/react-tabs';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import DateRangePicker, { DateRange } from '../../ui/DateRangePicker/DateRangePicker';
 import PrimaryButton from '../../ui/PrimaryButton/PrimaryButton';
 import { usePaymentRequestMetrics } from '../../../api/hooks/usePaymentRequestMetrics';
@@ -12,7 +12,6 @@ import { usePaymentRequests } from '../../../api/hooks/usePaymentRequests';
 import { LocalPaymentRequest } from '../../../types/LocalTypes';
 import { makeToast } from '../../ui/Toast/Toast';
 import { RemotePaymentRequestToLocalPaymentRequest } from '../../../utils/parsers';
-import classNames from 'classnames';
 import CreatePaymentRequestPage from '../../functional/CreatePaymentRequestPage/CreatePaymentRequestPage';
 import { add, startOfDay, endOfDay } from 'date-fns';
 
@@ -32,7 +31,6 @@ const PaymentRequestDashboard = ({
   const [createdSortDirection, setCreatedSortDirection] = useState<SortDirection>(SortDirection.NONE);
   const [contactSortDirection, setContactSortDirection] = useState<SortDirection>(SortDirection.NONE);
   const [amountSortDirection, setAmountSortDirection] = useState<SortDirection>(SortDirection.NONE);
-  const [selectedTab, setSelectedTab] = useState(PaymentRequestStatus.All);
   const [status, setStatus] = useState<PaymentRequestStatus>(PaymentRequestStatus.All);
   const [dateRange, setDateRange] = useState<DateRange>({
     fromDate: startOfDay(add(new Date(), { days: -90 })), // Last 90 days as default

--- a/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -39,8 +39,6 @@ const PaymentRequestDashboard = ({
 
   let [isCreatePaymentRequestOpen, setIsCreatePaymentRequestOpen] = useState(false);
 
-  const tabsContentClasses = 'bg-white p-6 h-full';
-
   const pageSize = 20;
   const nextGenUrl = `${apiUrl}/nextgen/pay`;
 

--- a/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -44,7 +44,12 @@ const PaymentRequestDashboard = ({
 
   const client = new PaymentRequestClient(apiUrl, token, merchantId);
 
-  const { paymentRequests, totalRecords, fetchPaymentRequests, isLoading } = usePaymentRequests(
+  const {
+    paymentRequests,
+    totalRecords,
+    fetchPaymentRequests,
+    isLoading: isLoadingPaymentRequests,
+  } = usePaymentRequests(
     apiUrl,
     token,
     merchantId,
@@ -62,7 +67,7 @@ const PaymentRequestDashboard = ({
   const localPaymentRequests: LocalPaymentRequest[] =
     paymentRequests?.map((paymentRequest) => RemotePaymentRequestToLocalPaymentRequest(paymentRequest)) ?? [];
 
-  const { metrics, apiError } = usePaymentRequestMetrics(
+  const { metrics, isLoading: isLoadingMetrics } = usePaymentRequestMetrics(
     apiUrl,
     token,
     merchantId,
@@ -148,10 +153,18 @@ const PaymentRequestDashboard = ({
         >
           {/* Keep the Tab to still get accessibility functions through the keyboard */}
           <Tabs.List className="flex shrink-0 gap-x-4 mb-4">
-            <Tab status={PaymentRequestStatus.All} totalRecords={metrics?.all ?? 0}></Tab>
-            <Tab status={PaymentRequestStatus.None} totalRecords={metrics?.unpaid ?? 0}></Tab>
-            <Tab status={PaymentRequestStatus.PartiallyPaid} totalRecords={metrics?.partiallyPaid ?? 0}></Tab>
-            <Tab status={PaymentRequestStatus.FullyPaid} totalRecords={metrics?.paid ?? 0}></Tab>
+            <Tab status={PaymentRequestStatus.All} isLoading={isLoadingMetrics} totalRecords={metrics?.all ?? 0} />
+            <Tab status={PaymentRequestStatus.None} isLoading={isLoadingMetrics} totalRecords={metrics?.unpaid ?? 0} />
+            <Tab
+              status={PaymentRequestStatus.PartiallyPaid}
+              isLoading={isLoadingMetrics}
+              totalRecords={metrics?.partiallyPaid ?? 0}
+            />
+            <Tab
+              status={PaymentRequestStatus.FullyPaid}
+              isLoading={isLoadingMetrics}
+              totalRecords={metrics?.paid ?? 0}
+            />
           </Tabs.List>
           <Tabs.Content value=""></Tabs.Content>
 
@@ -168,7 +181,7 @@ const PaymentRequestDashboard = ({
               onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
               onPaymentRequestDeleteClicked={onDeletePaymentRequest}
               onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
-              isLoading={isLoading}
+              isLoading={isLoadingPaymentRequests}
             />
           </div>
         </Tabs.Root>

--- a/src/components/ui/Tab/Tab.stories.tsx
+++ b/src/components/ui/Tab/Tab.stories.tsx
@@ -8,6 +8,10 @@ export default {
   component: Tab,
   argTypes: {
     totalRecords: { control: 'number' },
+    isLoading: { control: 'boolean' },
+  },
+  args: {
+    isLoading: false,
   },
 } as Meta<typeof Tab>;
 
@@ -35,6 +39,14 @@ export const All = Template.bind({});
 All.args = {
   status: PaymentRequestStatus.All,
   totalRecords: 112,
+};
+
+export const AllLoading = Template.bind({});
+
+AllLoading.args = {
+  status: PaymentRequestStatus.All,
+  totalRecords: 182,
+  isLoading: true,
 };
 
 export const Unpaid = Template.bind({});

--- a/src/components/ui/Tab/Tab.stories.tsx
+++ b/src/components/ui/Tab/Tab.stories.tsx
@@ -1,8 +1,7 @@
-import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
-import React from 'react';
 import { PaymentRequestStatus } from '../../../api/types/Enums';
 import Tab from './Tab';
+import * as Tabs from '@radix-ui/react-tabs';
 
 export default {
   title: 'UI/Tab',
@@ -12,7 +11,17 @@ export default {
   },
 } as Meta<typeof Tab>;
 
-const Template: StoryFn<typeof Tab> = (args) => <Tab {...args} />;
+const Template: StoryFn<typeof Tab> = (args) => {
+  return (
+    <Tabs.Root onValueChange={() => {}}>
+      {/* Keep the Tab to still get accessibility functions through the keyboard */}
+      <Tabs.List className="flex shrink-0 gap-x-4 mb-4">
+        <Tab {...args}></Tab>
+      </Tabs.List>
+      <Tabs.Content value=""></Tabs.Content>
+    </Tabs.Root>
+  );
+};
 
 export const Showcase = Template.bind({});
 

--- a/src/components/ui/Tab/Tab.tsx
+++ b/src/components/ui/Tab/Tab.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 export interface TabProps {
   status: PaymentRequestStatus;
   totalRecords: number;
+  isLoading?: boolean;
 }
 
 const getSpecificStatusClasses = (status: PaymentRequestStatus) => {
@@ -40,7 +41,7 @@ const showIndicator = (status: PaymentRequestStatus) => {
   }
 };
 
-const Tab = ({ status, totalRecords }: TabProps) => {
+const Tab = ({ status, totalRecords, isLoading = false }: TabProps) => {
   return (
     <Tabs.Trigger
       value={status}
@@ -49,7 +50,7 @@ const Tab = ({ status, totalRecords }: TabProps) => {
         getSpecificStatusClasses(status),
       )}
     >
-      <span className="text-sm/6 font-normal flex items-center">
+      <span className="text-sm/6 font-normal flex items-center mb-4">
         {showIndicator(status) && (
           <div className="items-center whitespace-nowrap inline-block mr-1.5">
             <svg width="6" height="6" viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg" className="fill-inherit">
@@ -60,7 +61,26 @@ const Tab = ({ status, totalRecords }: TabProps) => {
 
         {getDisplayTextForStatus(status)}
       </span>
-      <span className="text-[1.75rem]/6 font-medium mt-4">{totalRecords}</span>
+
+      <div className="relative flex">
+        <div
+          className={classNames(
+            'animate-pulse absolute left-1/2 top-0 bottom-0 my-auto -translate-x-1/2 flex items-center',
+            {
+              invisible: !isLoading,
+            },
+          )}
+        >
+          <div className="h-2 w-8 bg-[#E0E9EB] rounded-lg"></div>
+        </div>
+        <span
+          className={classNames('text-[1.75rem]/6 font-medium', {
+            invisible: isLoading,
+          })}
+        >
+          {totalRecords}
+        </span>
+      </div>
     </Tabs.Trigger>
   );
 };

--- a/src/components/ui/Tab/Tab.tsx
+++ b/src/components/ui/Tab/Tab.tsx
@@ -7,11 +7,12 @@ export interface TabProps {
   totalRecords: number;
 }
 
-const ellipseClassNames = (status: string) => {
+const getSpecificStatusClasses = (status: PaymentRequestStatus) => {
   return classNames({
-    'fill-[#ABB2BA]': status === PaymentRequestStatus.None,
-    'fill-[#E88C30]': status === PaymentRequestStatus.PartiallyPaid,
-    'fill-[#00CC88]': status === PaymentRequestStatus.FullyPaid,
+    "fill-[#ABB2BA] data-[state='active']:border-[#73808C]": status === PaymentRequestStatus.None,
+    "fill-[#ABB2BA] data-[state='active']:border-[#40BFBF]": status === PaymentRequestStatus.All,
+    "fill-[#E88C30] data-[state='active']:border-[#E88C30]": status === PaymentRequestStatus.PartiallyPaid,
+    "fill-[#00CC88] data-[state='active']:border-[#29A37A]": status === PaymentRequestStatus.FullyPaid,
   });
 };
 
@@ -44,8 +45,8 @@ const Tab = ({ status, totalRecords }: TabProps) => {
     <Tabs.Trigger
       value={status}
       className={classNames(
-        ellipseClassNames(status),
-        "flex flex-col items-center px-8 rounded-lg pt-6 pb-8 bg-white border-2 border-transparent transition w-full data-[state='active']:border-primaryGreen",
+        'flex flex-col items-center px-8 rounded-lg pt-6 pb-8 bg-white border-2 border-transparent transition w-full hover:border-borderGrey',
+        getSpecificStatusClasses(status),
       )}
     >
       <span className="text-sm/6 font-normal flex items-center">

--- a/src/components/ui/Tab/Tab.tsx
+++ b/src/components/ui/Tab/Tab.tsx
@@ -1,8 +1,4 @@
-import ellipseGrey from '../../../assets/images/ellipse.grey.svg';
-import ellipseGreen from '../../../assets/images/ellipse.green.svg';
-import ellipseOrange from '../../../assets/images/ellipse.orange.svg';
-import ellipse from '../../../assets/images/ellipse.svg';
-
+import * as Tabs from '@radix-ui/react-tabs';
 import { PaymentRequestStatus } from '../../../api/types/Enums';
 import classNames from 'classnames';
 
@@ -12,24 +8,11 @@ export interface TabProps {
 }
 
 const ellipseClassNames = (status: string) => {
-  return classNames('mr-1.5', {
+  return classNames({
     'fill-[#ABB2BA]': status === PaymentRequestStatus.None,
     'fill-[#E88C30]': status === PaymentRequestStatus.PartiallyPaid,
     'fill-[#00CC88]': status === PaymentRequestStatus.FullyPaid,
   });
-};
-
-const getIconFillForStatus = (status: PaymentRequestStatus) => {
-  switch (status) {
-    case PaymentRequestStatus.PartiallyPaid:
-      return ellipse;
-    case PaymentRequestStatus.FullyPaid:
-      return ellipse;
-    case PaymentRequestStatus.None:
-      return ellipse;
-    default:
-      return;
-  }
 };
 
 const getDisplayTextForStatus = (status: PaymentRequestStatus) => {
@@ -45,27 +28,39 @@ const getDisplayTextForStatus = (status: PaymentRequestStatus) => {
   }
 };
 
+const showIndicator = (status: PaymentRequestStatus) => {
+  switch (status) {
+    case PaymentRequestStatus.None:
+    case PaymentRequestStatus.PartiallyPaid:
+    case PaymentRequestStatus.FullyPaid:
+      return true;
+    default:
+      return false;
+  }
+};
+
 const Tab = ({ status, totalRecords }: TabProps) => {
   return (
-    <div>
-      <div className="flex flex-col items-center px-8">
-        <span className="text-[1.25rem] leading-7 font-semibold tabular-nums">{totalRecords}</span>
-        <div className="flex items-center whitespace-nowrap">
-          {getIconFillForStatus(status) && (
-            <svg
-              width="6"
-              height="6"
-              viewBox="0 0 6 6"
-              xmlns="http://www.w3.org/2000/svg"
-              className={ellipseClassNames(status)}
-            >
+    <Tabs.Trigger
+      value={status}
+      className={classNames(
+        ellipseClassNames(status),
+        "flex flex-col items-center px-8 rounded-lg pt-6 pb-8 bg-white border-2 border-transparent transition w-full data-[state='active']:border-primaryGreen",
+      )}
+    >
+      <span className="text-sm/6 font-normal flex items-center">
+        {showIndicator(status) && (
+          <div className="items-center whitespace-nowrap inline-block mr-1.5">
+            <svg width="6" height="6" viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg" className="fill-inherit">
               <circle cx="3" cy="3" r="3" />
             </svg>
-          )}
-          <span className="text-sm leading-6 font-normal">{getDisplayTextForStatus(status)}</span>
-        </div>
-      </div>
-    </div>
+          </div>
+        )}
+
+        {getDisplayTextForStatus(status)}
+      </span>
+      <span className="text-[1.75rem]/6 font-medium mt-4">{totalRecords}</span>
+    </Tabs.Trigger>
   );
 };
 


### PR DESCRIPTION
This pull request introduces a new design for the Status filter (previously referred to as Tabs) in the Payment Requests Table.

Notably, accessibility features have been maintained in this implementation. Users can navigate to the status filter using the TAB key, and then switch between statuses using the arrow keys (← and →). Importantly, the status will not change when continuing to press the TAB key.

Demo video:

https://github.com/nofrixion/nofrixion.webcomponents/assets/52673485/8ef117c8-d0e6-48f5-ab15-27cf75d8a702


