### PR TITLE
Update URL Structure for Payment Request Links

### DIFF
--- a/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -96,8 +96,6 @@ const PaymentRequestDashboard = ({
     let link = `${paymentRequest.hostedPayCheckoutUrl}/nextgen`;
     await navigator.clipboard.writeText(link);
 
-    console.log(paymentRequest);
-
     makeToast('success', 'Link copied into clipboard.');
   };
 


### PR DESCRIPTION
This pull request rectifies the URL structure when copying the link for a Payment Request. Previously, the copied URL took the form of https://api-dev.nofrixion.com/api/v1/nextgen/pay/..., which has now been corrected to https://api-dev.nofrixion.com/pay/....

The solution involves extracting the `hostedPayCheckoutUrl` directly from the Payment Request prop. An addition to the URL structure is the `nextgen` suffix, which aligns with the new Hosted Payment Page URL in accordance with MOOV-1768 (https://nofrixion.atlassian.net/browse/MOOV-1768). This ensures that the URL for a Payment Request matches the NextGen Hosted Payment Page if the user is viewing the new Table.