### PR TITLE
Bugfix/moov 1806 priority bank render

### DIFF
--- a/src/components/ui/utils/AnimateHeight.tsx
+++ b/src/components/ui/utils/AnimateHeight.tsx
@@ -4,7 +4,6 @@ const AnimateHeightWrapper = ({ children, layoutId }: { children: React.ReactNod
   return (
     <motion.div
       layoutId={layoutId}
-      className=""
       initial={{ opacity: 0, height: 0 }}
       animate={{
         opacity: 1,

--- a/src/components/ui/utils/AnimateHeight.tsx
+++ b/src/components/ui/utils/AnimateHeight.tsx
@@ -4,7 +4,7 @@ const AnimateHeightWrapper = ({ children, layoutId }: { children: React.ReactNod
   return (
     <motion.div
       layoutId={layoutId}
-      className="overflow-hidden"
+      className=""
       initial={{ opacity: 0, height: 0 }}
       animate={{
         opacity: 1,


### PR DESCRIPTION
Removed 'overflow-hidden' class on AnimateHeight component to allow priority bank list to display correctly. Tested on other usages of the component with no issues. 