### PR TITLE
Functional payment request details modal.

### DIFF
--- a/src/api/clients/BaseApiClient.ts
+++ b/src/api/clients/BaseApiClient.ts
@@ -78,13 +78,7 @@ export abstract class BaseApiClient {
   }> {
     console.log(`Requesting: ${method} ${url}`);
 
-    let contentType = 'application/json';
-
-    // Send form encoding on POST and PUT
-    // Axios will automatically serialize the postData object to form urlencoded format
-    if (method === HttpMethod.POST || method === HttpMethod.PUT) {
-      contentType = 'application/x-www-form-urlencoded';
-    }
+    const contentType = 'application/json';
 
     try {
       const { data } = await axios<TResponse>({

--- a/src/api/clients/PaymentRequestClient.ts
+++ b/src/api/clients/PaymentRequestClient.ts
@@ -4,6 +4,8 @@ import {
   PaymentRequestMetrics,
   PaymentRequestMinimal,
   PaymentRequestPageResponse,
+  PaymentRequest,
+  PaymentRequestUpdate,
 } from '../types/ApiResponses';
 import { HttpMethod, PaymentRequestStatus } from '../types/Enums';
 import { BaseApiClient } from './BaseApiClient';
@@ -99,14 +101,22 @@ export class PaymentRequestClient extends BaseApiClient {
 
   /**
    * Updates a Payment request
-   * @param paymentRequest The Payment Request to update
+   * @param paymentRequestId The ID of the Payment Request to update.
+   * @param paymentRequestUpdate The Payment Request update object with the updated values.
    * @returns The updated PaymentRequest if successful. An ApiError if not successful.
    */
-  async update(paymentRequest: PaymentRequestCreate): Promise<{
+  async update(
+    paymentRequestId: string,
+    paymentRequestUpdate: PaymentRequestUpdate,
+  ): Promise<{
     data?: PaymentRequest;
     error?: ApiError;
   }> {
-    const response = await this.httpRequest<PaymentRequest>(this.apiUrl, HttpMethod.PUT, paymentRequest);
+    const response = await this.httpRequest<PaymentRequest>(
+      `${this.apiUrl}/${paymentRequestId}`,
+      HttpMethod.PUT,
+      paymentRequestUpdate,
+    );
 
     return response;
   }

--- a/src/api/hooks/useMerchantTags.ts
+++ b/src/api/hooks/useMerchantTags.ts
@@ -2,23 +2,24 @@ import { useEffect, useState } from 'react';
 import { MerchantClient } from '../clients/MerchantClient';
 import { ApiError, Tag } from '../types/ApiResponses';
 
-export const useMerchantTags = (apiUrl: string, authToken: string, merchantId: string) => {
+export const useMerchantTags = (authToken: string, merchantId: string, apiUrl?: string) => {
   const [tags, setTags] = useState<Tag[]>();
   const [apiError, setApiError] = useState<ApiError>();
 
   useEffect(() => {
-    const fetchMerchantTags = async () => {
-      const client = new MerchantClient(apiUrl, authToken, merchantId);
-      const response = await client.getTags();
+    if (apiUrl) {
+      const fetchMerchantTags = async () => {
+        const client = new MerchantClient(apiUrl, authToken, merchantId);
+        const response = await client.getTags();
 
-      if (response.data) {
-        setTags(response.data);
-      } else if (response.error) {
-        setApiError(response.error);
-      }
-    };
-
-    fetchMerchantTags();
+        if (response.data) {
+          setTags(response.data);
+        } else if (response.error) {
+          setApiError(response.error);
+        }
+      };
+      fetchMerchantTags();
+    }
   }, [apiUrl, authToken, merchantId]);
 
   return {

--- a/src/api/hooks/usePaymentRequest.ts
+++ b/src/api/hooks/usePaymentRequest.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { PaymentRequestClient } from '../clients/PaymentRequestClient';
-import { ApiError } from '../types/ApiResponses';
+import { ApiError, PaymentRequest } from '../types/ApiResponses';
 
 export const usePaymentRequest = (paymentRequestId: string, apiUrl: string, authToken: string, merchantId: string) => {
   const [paymentRequest, setPaymentRequest] = useState<PaymentRequest>();

--- a/src/api/types/ApiResponses.ts
+++ b/src/api/types/ApiResponses.ts
@@ -3,9 +3,12 @@ import {
   CardTokenCreateModes,
   Currency,
   PartialPaymentMethods,
+  PaymentMethodTypes,
   PaymentProcessor,
   PaymentRequestEventType,
+  PaymentRequestStatus,
   PaymentResult,
+  Wallets,
 } from './Enums';
 
 export type PaymentRequestPageResponse = PageResponse<PaymentRequest>;
@@ -47,6 +50,26 @@ export type PaymentRequest = {
   tags: Tag[];
   priorityBankID?: string;
   title?: string;
+  paymentAttempts: PaymentRequestPaymentAttempt[];
+};
+
+export type PaymentRequestPaymentAttempt = {
+  attemptKey: string;
+  paymentRequestID: string;
+  initiatedAt: Date;
+  authorisedAt?: Date;
+  settledAt?: Date;
+  refundedAt?: Date;
+  settleFailedAt?: Date;
+  paymentMethod: PaymentMethodTypes;
+  attemptedAmount: number;
+  authorisedAmount: number;
+  settledAmount: number;
+  refundedAmount: number;
+  currency: Currency.EUR | Currency.GBP;
+  paymentProcessor: PaymentProcessor;
+  status: PaymentRequestStatus;
+  walletName?: Wallets;
 };
 
 export type PaymentRequestMinimal = {
@@ -99,6 +122,39 @@ export type PaymentRequestCreate = {
   shippingEmail?: string;
   priorityBankID?: string;
   title?: string;
+  tagIds?: string[];
+};
+
+export type PaymentRequestUpdate = {
+  amount?: number;
+  currency?: Currency;
+  customerID?: string;
+  orderID?: string;
+  paymentMethodTypes?: string;
+  description?: string;
+  pispAccountID?: string;
+  shippingFirstName?: string;
+  shippingLastName?: string;
+  shippingAddressLine1?: string;
+  shippingAddressLine2?: string;
+  shippingAddressCity?: string;
+  shippingAddressCounty?: string;
+  shippingAddressPostCode?: string;
+  shippingAddressCountryCode?: string;
+  shippingPhone?: string;
+  shippingEmail?: string;
+  baseOriginUrl?: string;
+  callbackUrl?: string;
+  cardAuthorizeOnly?: boolean;
+  cardCreateToken?: boolean;
+  ignoreAddressVerification?: boolean;
+  cardIgnoreCVN?: boolean;
+  pispRecipientReference?: string;
+  cardProcessorMerchantID?: string;
+  customerEmailAddress?: string;
+  notificationEmailAddresses?: string[];
+  title?: string;
+  partialPaymentSteps?: string;
   tagIds?: string[];
 };
 
@@ -162,7 +218,7 @@ export type ApiResponse<T> = {
 };
 
 export type Tag = {
-  ID?: string;
+  id: string;
   merchantID?: string;
   name: string;
   colourHex?: string;

--- a/src/api/types/Enums.ts
+++ b/src/api/types/Enums.ts
@@ -75,3 +75,16 @@ export enum PaymentRequestStatus {
   Voided = 'Voided',
   Authorized = 'Authorized',
 }
+
+export enum PaymentMethodTypes {
+  Card = 'card',
+  Pisp = 'pisp',
+  ApplePay = 'applepay',
+  GooglePay = 'googlepay',
+  Lightning = 'lightning',
+}
+
+export enum Wallets {
+  ApplePay = 'ApplePay',
+  GooglePay = 'GooglePay',
+}

--- a/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -17,6 +17,7 @@ import { add, startOfDay, endOfDay } from 'date-fns';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
 import LayoutWrapper from '../../ui/utils/LayoutWrapper';
 import { PaymentRequestMetrics } from '../../../api/types/ApiResponses';
+import PaymentRequestDetailsModal from '../PaymentRequestDetailsModal/PaymentRequestDetailsModal';
 
 interface PaymentRequestDashboardProps {
   token: string; // Example: "eyJhbGciOiJIUz..."
@@ -42,9 +43,22 @@ const PaymentRequestDashboard = ({
 
   let [isCreatePaymentRequestOpen, setIsCreatePaymentRequestOpen] = useState(false);
 
+  const [selectedPaymentRequest, setSelectedPaymentRequest] = useState<LocalPaymentRequest | null>(null);
+  const [showPaymentRequestDetailsModal, setShowPaymentRequestDetailsModal] = useState<boolean>(false);
+
   const pageSize = 20;
 
   const client = new PaymentRequestClient(apiUrl, token, merchantId);
+
+  const onPaymentRequestRowClicked = (paymentRequest: LocalPaymentRequest) => {
+    setSelectedPaymentRequest(paymentRequest);
+    setShowPaymentRequestDetailsModal(true);
+  };
+
+  const onPaymentRequestDetailsModalDismiss = () => {
+    setSelectedPaymentRequest(null);
+    setShowPaymentRequestDetailsModal(false);
+  };
 
   const {
     paymentRequests,
@@ -222,6 +236,7 @@ const PaymentRequestDashboard = ({
             isLoading={isLoadingPaymentRequests}
             isEmpty={isInitialState}
             onCreatePaymentRequest={onCreatePaymentRequest}
+            onPaymentRequestClicked={onPaymentRequestRowClicked}
           />
         </LayoutWrapper>
       </LayoutGroup>
@@ -233,6 +248,16 @@ const PaymentRequestDashboard = ({
         merchantId={merchantId}
         apiUrl={apiUrl}
       />
+      {selectedPaymentRequest && (
+        <PaymentRequestDetailsModal
+          token={token}
+          apiUrl={apiUrl}
+          merchantId={merchantId}
+          paymentRequestID={selectedPaymentRequest.id}
+          open={showPaymentRequestDetailsModal}
+          onDismiss={onPaymentRequestDetailsModalDismiss}
+        ></PaymentRequestDetailsModal>
+      )}
     </div>
   );
 };

--- a/src/components/functional/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
+++ b/src/components/functional/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { useMerchantTags } from '../../../api/hooks/useMerchantTags';
+import UIPaymentRequestDetailsModal from '../../ui/PaymentRequestDetailsModal/PaymentRequestDetailsModal';
+import { RemotePaymentRequestToLocalPaymentRequest, parseApiTagToLocalTag } from '../../../utils/parsers';
+import { LocalTag } from '../../../types/LocalTypes';
+import { PaymentRequestClient } from '../../../api/clients/PaymentRequestClient';
+import { PaymentRequest, PaymentRequestUpdate } from '../../../api/types/ApiResponses';
+import { MerchantClient } from '../../../api/clients/MerchantClient';
+
+interface PaymentRequestDetailsModalProps {
+  token: string; // Example: "eyJhbGciOiJIUz..."
+  apiUrl: string; // Example: "https://api.nofrixion.com/api/v1"
+  merchantId: string;
+  paymentRequestID: string;
+  open: boolean;
+  onDismiss: () => void;
+}
+const PaymentRequestDetailsModal = ({
+  token,
+  apiUrl,
+  merchantId,
+  paymentRequestID,
+  open,
+  onDismiss,
+}: PaymentRequestDetailsModalProps) => {
+  const paymentRequestClient = new PaymentRequestClient(apiUrl, token, merchantId);
+  const merchantClient = new MerchantClient(apiUrl, token, merchantId);
+  const merchantTags = useMerchantTags(token, merchantId, apiUrl);
+  const [localMerchantTags, setLocalMerchantTags] = useState<LocalTag[]>([] as LocalTag[]);
+  const [paymentRequest, setPaymentRequest] = useState<PaymentRequest | undefined>();
+
+  const onRefundClick = async (paymentAttemptID: string) => {
+    //TODO: Will implement refund for atleast card payment attempts. For PISP, it will need to be worked on later.
+    console.log(paymentAttemptID);
+  };
+
+  const onTagAdded = async (tag: LocalTag) => {
+    if (paymentRequest) {
+      const existingTagIds = paymentRequest.tags?.map((tag) => tag.id) ?? [];
+      const paymentRequestUpdate: PaymentRequestUpdate = {
+        tagIds: existingTagIds.concat(tag.id),
+      };
+      const paymentRequestTagAdd = await paymentRequestClient.update(paymentRequest.id, paymentRequestUpdate);
+      if (paymentRequestTagAdd.error) {
+        console.log(paymentRequestTagAdd.error);
+      } else {
+        setPaymentRequest(paymentRequestTagAdd.data);
+      }
+    }
+  };
+
+  const onTagCreated = async (tag: LocalTag) => {
+    if (paymentRequest) {
+      const response = await merchantClient.addTag(parseApiTagToLocalTag(tag));
+      if (response.error) {
+        console.log(response.error);
+      } else {
+        const createdTag = response.data;
+        if (createdTag) {
+          const existingTagIds = paymentRequest.tags?.map((tag) => tag.id) ?? [];
+          const paymentRequestUpdate: PaymentRequestUpdate = {
+            tagIds: existingTagIds.concat(createdTag.id),
+          };
+          const paymentRequestTagAdd = await paymentRequestClient.update(paymentRequest.id, paymentRequestUpdate);
+          if (paymentRequestTagAdd.error) {
+            console.log(paymentRequestTagAdd.error);
+          } else {
+            setPaymentRequest(paymentRequestTagAdd.data);
+          }
+        }
+      }
+    }
+  };
+
+  const onTagDeleted = async (tagIdToDelete: string) => {
+    if (paymentRequest) {
+      const existingTagIds = paymentRequest.tags?.map((tag) => tag.id) ?? [];
+      const paymentRequestUpdate: PaymentRequestUpdate = {
+        tagIds: existingTagIds.filter((id) => id !== tagIdToDelete),
+      };
+      const paymentRequestTagDelete = await paymentRequestClient.update(paymentRequest.id, paymentRequestUpdate);
+      if (paymentRequestTagDelete.error) {
+        console.log(paymentRequestTagDelete.error);
+      } else {
+        setPaymentRequest(paymentRequestTagDelete.data);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (merchantTags.tags) {
+      setLocalMerchantTags(merchantTags.tags.map((tag) => parseApiTagToLocalTag(tag)));
+    }
+  }, [merchantTags.tags]);
+
+  useEffect(() => {
+    const fetchPaymentRequest = async () => {
+      const response = await paymentRequestClient.get(paymentRequestID, true);
+      if (response.error) {
+        return;
+      }
+      if (response.data) {
+        setPaymentRequest(response.data);
+      }
+    };
+    fetchPaymentRequest();
+  }, [apiUrl, token, merchantId]);
+
+  return (
+    <div>
+      {paymentRequest && (
+        <UIPaymentRequestDetailsModal
+          merchantTags={localMerchantTags}
+          paymentRequest={RemotePaymentRequestToLocalPaymentRequest(paymentRequest)}
+          open={open}
+          onRefundClick={onRefundClick}
+          onTagAdded={onTagAdded}
+          onTagCreated={onTagCreated}
+          onTagDeleted={onTagDeleted}
+          onDismiss={onDismiss}
+        ></UIPaymentRequestDetailsModal>
+      )}
+    </div>
+  );
+};
+
+export default PaymentRequestDetailsModal;

--- a/src/components/ui/PaymentRequestDetails/PaymentRequestDetails.tsx
+++ b/src/components/ui/PaymentRequestDetails/PaymentRequestDetails.tsx
@@ -30,7 +30,7 @@ const PaymentRequestDetails = ({
           <Contact name={paymentRequest.contact.name} email={paymentRequest.contact.email} size="large"></Contact>
           <QRCode url={paymentRequest.hostedPayCheckoutUrl}></QRCode>
         </div>
-        <div className="absolute left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-opacity-100 z-10 w-[92%]">
+        <div className="absolute left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-opacity-100 w-[92%]">
           <CopyLink link={paymentRequest.hostedPayCheckoutUrl}></CopyLink>
         </div>
       </div>
@@ -61,7 +61,7 @@ const PaymentRequestDetails = ({
           ></TagManager>
         </div>
         <div className="relative">
-          <div className="absolute z-0 left-0 right-0">
+          <div className="absolute left-0 right-0 mb-6">
             <DetailsTabs paymentRequest={paymentRequest} onRefundClick={onRefundClick}></DetailsTabs>
           </div>
         </div>

--- a/src/components/ui/PaymentRequestDetailsModal/PaymentRequestDetailsModal.stories.tsx
+++ b/src/components/ui/PaymentRequestDetailsModal/PaymentRequestDetailsModal.stories.tsx
@@ -1,0 +1,50 @@
+import { StoryFn, Meta } from '@storybook/react';
+import PaymentRequestDetailsModal from './PaymentRequestDetailsModal';
+import mockedData from '../../../utils/mockedData';
+import { useState } from 'react';
+
+export default {
+  title: 'UI/PaymentRequestDetailsModal',
+  component: PaymentRequestDetailsModal,
+  argTypes: {
+    onDismiss: {
+      action: 'Dismiss',
+    },
+    onRefundClick: { action: 'refund clicked' },
+    onTagAdded: { action: 'tag added' },
+    onTagCreated: { action: 'tag created' },
+    onTagDeleted: { action: 'tag deleted' },
+  },
+} as Meta<typeof PaymentRequestDetailsModal>;
+
+const Template: StoryFn<typeof PaymentRequestDetailsModal> = (args) => {
+  let [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => {
+    setIsOpen(true);
+  };
+  const onClose = () => {
+    setIsOpen(false);
+  };
+  return (
+    <>
+      <div className=" flex items-center justify-center">
+        <button
+          type="button"
+          onClick={openModal}
+          className="rounded-md bg-black bg-opacity-80 px-4 py-2 text-sm font-medium text-white hover:bg-opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75"
+        >
+          I am a payment request row. Click me.
+        </button>
+      </div>
+      <PaymentRequestDetailsModal {...args} open={isOpen} onDismiss={onClose}></PaymentRequestDetailsModal>
+    </>
+  );
+};
+
+export const Showcase = Template.bind({});
+Showcase.args = {
+  open: false,
+  paymentRequest: mockedData.paymentRequest.regular,
+  merchantTags: mockedData.merchantTags,
+};

--- a/src/components/ui/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
+++ b/src/components/ui/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
@@ -1,0 +1,71 @@
+import { Fragment, useState } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import Checkbox from '../Checkbox/Checkbox';
+import PaymentRequestDetails from '../PaymentRequestDetails/PaymentRequestDetails';
+import { LocalPaymentRequest, LocalTag } from '../../../types/LocalTypes';
+
+export interface PaymentRequestDetailsModalProps {
+  paymentRequest: LocalPaymentRequest;
+  merchantTags: LocalTag[];
+  onRefundClick: (paymentAttemptID: string) => void;
+  onTagAdded: (tag: LocalTag) => void;
+  onTagDeleted: (id: string) => void;
+  onTagCreated: (tag: LocalTag) => void;
+  open: boolean;
+  onDismiss: () => void;
+}
+
+const PaymentRequestDetailsModal = ({
+  paymentRequest,
+  merchantTags,
+  onRefundClick,
+  onTagAdded,
+  onTagDeleted,
+  onTagCreated,
+  open,
+  onDismiss,
+}: PaymentRequestDetailsModalProps) => {
+  return (
+    <Transition appear show={open} as={Fragment}>
+      <Dialog as="div" onClose={onDismiss}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-linear duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-linear duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-5" />
+        </Transition.Child>
+        <div className="fixed inset-0 overflow-y-auto">
+          <Transition.Child
+            as={Fragment}
+            enter="duration-300 transform"
+            enterFrom="translate-x-full"
+            enterTo="translate-x-0"
+            leave="duration-300 transform"
+            leaveFrom="translate-x-0"
+            leaveTo="translate-x-full"
+          >
+            <Dialog.Panel>
+              <div className="w-[37.5rem] h-[63.438rem] overflow-auto float-right bg-white">
+                <PaymentRequestDetails
+                  paymentRequest={paymentRequest}
+                  merchantTags={merchantTags}
+                  onRefundClick={onRefundClick}
+                  onTagAdded={onTagAdded}
+                  onTagDeleted={onTagDeleted}
+                  onTagCreated={onTagCreated}
+                />
+              </div>
+            </Dialog.Panel>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};
+
+export default PaymentRequestDetailsModal;

--- a/src/components/ui/Tags/AddTag/AddTag.tsx
+++ b/src/components/ui/Tags/AddTag/AddTag.tsx
@@ -58,7 +58,7 @@ const AddTag = ({ tags, availableTags, onTagAdded, onTagCreated }: TagProps) => 
       onTagCreated &&
         onTagCreated({
           name: tagName,
-          ID: uuidv4(), // This is here to make sure the tag key is unique in the list
+          id: uuidv4(), // This is here to make sure the tag key is unique in the list
         });
     }
     reset();

--- a/src/components/ui/Tags/TagManager/TagManager.tsx
+++ b/src/components/ui/Tags/TagManager/TagManager.tsx
@@ -16,7 +16,7 @@ const TagManager = ({ tags, availableTags, onDeleted, onAdded, onCreated }: TagM
   const [tagsArray, setTagsArray] = useState(tags);
 
   const handleDelete = (id: string) => {
-    setTagsArray(tagsArray.filter((item) => item.ID !== id));
+    setTagsArray(tagsArray.filter((item) => item.id !== id));
 
     onDeleted(id);
   };
@@ -41,7 +41,7 @@ const TagManager = ({ tags, availableTags, onDeleted, onAdded, onCreated }: TagM
     <div className="flex flex-wrap w-auto gap-x-2 gap-y-2">
       <AnimatePresence>
         {tagsArray.map((tag) => (
-          <Tag key={tag.ID} id={tag.ID!} label={tag.name} onDelete={handleDelete} />
+          <Tag key={tag.id} id={tag.id!} label={tag.name} onDelete={handleDelete} />
         ))}
         <AddTag
           key="addtag"

--- a/src/components/ui/Transactions/Transactions.tsx
+++ b/src/components/ui/Transactions/Transactions.tsx
@@ -1,4 +1,3 @@
-import { Currency } from '../../../api/types/Enums';
 import { LocalPaymentMethodTypes } from '../../../types/LocalEnums';
 import CardIcon from '../../../assets/icons/card-icon.svg';
 import BankIcon from '../../../assets/icons/bank-icon.svg';
@@ -34,7 +33,7 @@ const Transactions = ({
         {transactions.map((transaction, index) => (
           <tr key={index} className="border-b group">
             <td className={classNames('text-[0.813rem] pb-2 leading-6', { 'pt-2': index !== 0 })}>
-              {format(transaction.occurredAt, 'MMM do, yyyy')}
+              {transaction.occurredAt && format(transaction.occurredAt, 'MMM do, yyyy')}
             </td>
             <td className={classNames('pl-6 pb-2 text-right', { 'pt-2': index !== 0 })}>
               <span className="mr-2 text-sm tabular-nums font-medium leading-6">
@@ -62,7 +61,7 @@ const Transactions = ({
               <div className="w-[3.75rem] text-[0.813rem] h-6 ">
                 <div
                   className="text-[0.813rem] px-2 py-1 rounded-full bg-[#DEE6ED] leading-4 cursor-pointer opacity-0 transition group-hover:opacity-100 hover:bg-[#BDCCDB]"
-                  onClick={() => onRefundClicked(transaction.paymentAttemptID)}
+                  onClick={() => onRefundClicked(transaction.attemptKey)}
                 >
                   Refund
                 </div>

--- a/src/types/LocalEnums.ts
+++ b/src/types/LocalEnums.ts
@@ -1,4 +1,5 @@
 export enum LocalPaymentMethodTypes {
+  None = 'None',
   Card = 'card',
   Pisp = 'pisp',
   ApplePay = 'applepay',

--- a/src/types/LocalTypes.ts
+++ b/src/types/LocalTypes.ts
@@ -25,12 +25,12 @@ export interface LocalPaymentRequest {
 }
 
 export interface LocalPaymentAttempt {
-  paymentAttemptID: string;
+  attemptKey: string;
   occurredAt: Date;
   paymentMethod: LocalPaymentMethodTypes;
   amount: number;
   currency: Currency.EUR | Currency.GBP;
-  processor: string;
+  processor?: string;
   last4DigitsOfCardNumber?: string;
 }
 
@@ -92,7 +92,7 @@ export interface LocalPaymentMethodsFormValue {
 }
 
 export interface LocalTag {
-  ID?: string;
+  id: string;
   merchantID?: string;
   name: string;
   colourHex?: string;

--- a/src/utils/mockedData.ts
+++ b/src/utils/mockedData.ts
@@ -4,22 +4,22 @@ import { LocalPaymentAttempt, LocalPaymentRequest } from '../types/LocalTypes';
 
 export const mockTags = [
   {
-    ID: '1',
+    id: '1',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'A tag',
   },
   {
-    ID: '2',
+    id: '2',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'Another tag',
   },
   {
-    ID: '3',
+    id: '3',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'A reeeeallllly long tag name',
   },
   {
-    ID: '4',
+    id: '4',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'You get the idea',
   },
@@ -27,42 +27,42 @@ export const mockTags = [
 
 export const mockMerchantTags = [
   {
-    ID: '1',
+    id: '1',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'A tag',
   },
   {
-    ID: '2',
+    id: '2',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'Another tag',
   },
   {
-    ID: '3',
+    id: '3',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'A reeeeallllly long tag name',
   },
   {
-    ID: '4',
+    id: '4',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'You get the idea',
   },
   {
-    ID: '5',
+    id: '5',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'A merchant tag 1',
   },
   {
-    ID: '6',
+    id: '6',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'A merchant tag 2',
   },
   {
-    ID: '7',
+    id: '7',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'A merchant tag 3',
   },
   {
-    ID: '8',
+    id: '8',
     merchantID: '3780263C-5926-4B79-AC84-224D64290DBF',
     name: 'A merchant tag 4',
   },
@@ -70,7 +70,7 @@ export const mockMerchantTags = [
 
 export const mockPaymentAttempts: LocalPaymentAttempt[] = [
   {
-    paymentAttemptID: 'a3b752d2-c0a6-4846-90e5-d783bb4ec005',
+    attemptKey: 'a3b752d2-c0a6-4846-90e5-d783bb4ec005',
     occurredAt: new Date('2023-05-18'),
     paymentMethod: LocalPaymentMethodTypes.Card,
     amount: 20.02,
@@ -79,7 +79,7 @@ export const mockPaymentAttempts: LocalPaymentAttempt[] = [
     last4DigitsOfCardNumber: '1234',
   },
   {
-    paymentAttemptID: 'f4c6e747-6fd6-4a3c-be3b-4d3edd258b35',
+    attemptKey: 'f4c6e747-6fd6-4a3c-be3b-4d3edd258b35',
     occurredAt: new Date('2023-03-23'),
     paymentMethod: LocalPaymentMethodTypes.Card,
     amount: 30.57,
@@ -88,7 +88,7 @@ export const mockPaymentAttempts: LocalPaymentAttempt[] = [
     last4DigitsOfCardNumber: '1234',
   },
   {
-    paymentAttemptID: 'ca2eb453-9c12-4f8f-b8b2-7c1c6af842ba',
+    attemptKey: 'ca2eb453-9c12-4f8f-b8b2-7c1c6af842ba',
     occurredAt: new Date('2023-05-18'),
     paymentMethod: LocalPaymentMethodTypes.Pisp,
     amount: 5.34,
@@ -97,7 +97,7 @@ export const mockPaymentAttempts: LocalPaymentAttempt[] = [
     last4DigitsOfCardNumber: '1234',
   },
   {
-    paymentAttemptID: '43535f79-a9f2-4331-9a78-db731e467c49',
+    attemptKey: '43535f79-a9f2-4331-9a78-db731e467c49',
     occurredAt: new Date('2023-05-2'),
     paymentMethod: LocalPaymentMethodTypes.Pisp,
     amount: 7.9,
@@ -106,7 +106,7 @@ export const mockPaymentAttempts: LocalPaymentAttempt[] = [
     last4DigitsOfCardNumber: '1234',
   },
   {
-    paymentAttemptID: 'a9f6c19a-0172-47a6-803a-c3f59899cafc',
+    attemptKey: 'a9f6c19a-0172-47a6-803a-c3f59899cafc',
     occurredAt: new Date('2023-05-1'),
     paymentMethod: LocalPaymentMethodTypes.ApplePay,
     amount: 15.39,
@@ -114,7 +114,7 @@ export const mockPaymentAttempts: LocalPaymentAttempt[] = [
     processor: 'Apple Pay',
   },
   {
-    paymentAttemptID: '7bbb2998-8d78-4b2a-9334-84444c9915c8',
+    attemptKey: '7bbb2998-8d78-4b2a-9334-84444c9915c8',
     occurredAt: new Date('2023-05-18'),
     paymentMethod: LocalPaymentMethodTypes.GooglePay,
     amount: 20.78,
@@ -126,7 +126,7 @@ export const mockPaymentAttempts: LocalPaymentAttempt[] = [
 
 export const partiallyPaidMockPaymentAttempts: LocalPaymentAttempt[] = [
   {
-    paymentAttemptID: 'a3b752d2-c0a6-4846-90e5-d783bb4ec005',
+    attemptKey: 'a3b752d2-c0a6-4846-90e5-d783bb4ec005',
     occurredAt: new Date('2023-05-18'),
     paymentMethod: LocalPaymentMethodTypes.Card,
     amount: 20.02,
@@ -135,7 +135,7 @@ export const partiallyPaidMockPaymentAttempts: LocalPaymentAttempt[] = [
     last4DigitsOfCardNumber: '1234',
   },
   {
-    paymentAttemptID: 'f4c6e747-6fd6-4a3c-be3b-4d3edd258b35',
+    attemptKey: 'f4c6e747-6fd6-4a3c-be3b-4d3edd258b35',
     occurredAt: new Date('2023-03-23'),
     paymentMethod: LocalPaymentMethodTypes.Card,
     amount: 30.57,
@@ -147,7 +147,7 @@ export const partiallyPaidMockPaymentAttempts: LocalPaymentAttempt[] = [
 ];
 export const overpaidMockPaymentAttempts: LocalPaymentAttempt[] = [
   {
-    paymentAttemptID: 'a3b752d2-c0a6-4846-90e5-d783bb4ec005',
+    attemptKey: 'a3b752d2-c0a6-4846-90e5-d783bb4ec005',
     occurredAt: new Date('2023-05-18'),
     paymentMethod: LocalPaymentMethodTypes.Card,
     amount: 20.02,
@@ -156,7 +156,7 @@ export const overpaidMockPaymentAttempts: LocalPaymentAttempt[] = [
     last4DigitsOfCardNumber: '1234',
   },
   {
-    paymentAttemptID: 'f4c6e747-6fd6-4a3c-be3b-4d3edd258b35',
+    attemptKey: 'f4c6e747-6fd6-4a3c-be3b-4d3edd258b35',
     occurredAt: new Date('2023-03-23'),
     paymentMethod: LocalPaymentMethodTypes.Card,
     amount: 90.57,
@@ -259,14 +259,14 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     currency: Currency.EUR,
     tags: [
       {
-        ID: '1',
+        id: '1',
         description: 'Logo Design',
         colourHex: '#FF0000',
         name: 'Logo Design',
         merchantID: '1',
       },
       {
-        ID: '2',
+        id: '2',
         description: 'Web Design',
         colourHex: '#00FF00',
         name: 'Web Design',
@@ -292,21 +292,21 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     currency: Currency.EUR,
     tags: [
       {
-        ID: '3',
+        id: '3',
         description: 'App Development',
         colourHex: '#0000FF',
         name: 'App Development',
         merchantID: '1',
       },
       {
-        ID: '4',
+        id: '4',
         description: 'UI Design',
         colourHex: '#FF00FF',
         name: 'UI Design',
         merchantID: '1',
       },
       {
-        ID: '5',
+        id: '5',
         description: 'EU Client',
         colourHex: '#FFFF00',
         name: 'EU Client',
@@ -331,9 +331,9 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 2700,
     currency: Currency.GBP,
     tags: [
-      { ID: '6', description: 'ecommerce', colourHex: '#FF0000', name: 'ecommerce', merchantID: '1' },
-      { ID: '7', description: 'web-development', colourHex: '#00FF00', name: 'web-development', merchantID: '1' },
-      { ID: '8', description: 'London-client', colourHex: '#0000FF', name: 'London-client', merchantID: '1' },
+      { id: '6', description: 'ecommerce', colourHex: '#FF0000', name: 'ecommerce', merchantID: '1' },
+      { id: '7', description: 'web-development', colourHex: '#00FF00', name: 'web-development', merchantID: '1' },
+      { id: '8', description: 'London-client', colourHex: '#0000FF', name: 'London-client', merchantID: '1' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],
@@ -353,9 +353,9 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 2500,
     currency: Currency.GBP,
     tags: [
-      { ID: '9', description: 'web-design', colourHex: '#FF0000', name: 'web-design', merchantID: '1' },
-      { ID: '10', description: 'branding', colourHex: '#00FF00', name: 'branding', merchantID: '1' },
-      { ID: '11', description: 'London-client', colourHex: '#0000FF', name: 'London-client', merchantID: '1' },
+      { id: '9', description: 'web-design', colourHex: '#FF0000', name: 'web-design', merchantID: '1' },
+      { id: '10', description: 'branding', colourHex: '#00FF00', name: 'branding', merchantID: '1' },
+      { id: '11', description: 'London-client', colourHex: '#0000FF', name: 'London-client', merchantID: '1' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],
@@ -375,9 +375,9 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 3000,
     currency: Currency.GBP,
     tags: [
-      { ID: '7', description: 'web-development', colourHex: '#FF0000', name: 'web-development', merchantID: '1' },
-      { ID: '6', description: 'ecommerce', colourHex: '#00FF00', name: 'ecommerce', merchantID: '1' },
-      { ID: '11', description: 'London-client', colourHex: '#0000FF', name: 'London-client', merchantID: '1' },
+      { id: '7', description: 'web-development', colourHex: '#FF0000', name: 'web-development', merchantID: '1' },
+      { id: '6', description: 'ecommerce', colourHex: '#00FF00', name: 'ecommerce', merchantID: '1' },
+      { id: '11', description: 'London-client', colourHex: '#0000FF', name: 'London-client', merchantID: '1' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],
@@ -397,8 +397,8 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 1500,
     currency: Currency.GBP,
     tags: [
-      { ID: '7', description: 'web-development', colourHex: '#FF0000', name: 'web-development', merchantID: '1' },
-      { ID: '6', description: 'ecommerce', colourHex: '#00FF00', name: 'ecommerce', merchantID: '1' },
+      { id: '7', description: 'web-development', colourHex: '#FF0000', name: 'web-development', merchantID: '1' },
+      { id: '6', description: 'ecommerce', colourHex: '#00FF00', name: 'ecommerce', merchantID: '1' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],
@@ -418,9 +418,9 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 1200,
     currency: Currency.GBP,
     tags: [
-      { ID: '12', name: 'SEO', merchantID: '1', colourHex: '#000000', description: 'Search Engine Optimization' },
-      { ID: '13', name: 'content-creation', merchantID: '1', colourHex: '#000000', description: 'Content Creation' },
-      { ID: '14', name: 'London-client', merchantID: '1', colourHex: '#000000', description: 'London Client' },
+      { id: '12', name: 'SEO', merchantID: '1', colourHex: '#000000', description: 'Search Engine Optimization' },
+      { id: '13', name: 'content-creation', merchantID: '1', colourHex: '#000000', description: 'Content Creation' },
+      { id: '14', name: 'London-client', merchantID: '1', colourHex: '#000000', description: 'London Client' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],
@@ -440,9 +440,9 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 2300,
     currency: Currency.EUR,
     tags: [
-      { ID: '15', name: 'web-design', merchantID: '1', colourHex: '#000000', description: 'Web Design' },
-      { ID: '16', name: 'responsive-design', merchantID: '1', colourHex: '#000000', description: 'Responsive Design' },
-      { ID: '17', name: 'EU-client', merchantID: '1', colourHex: '#000000', description: 'EU Client' },
+      { id: '15', name: 'web-design', merchantID: '1', colourHex: '#000000', description: 'Web Design' },
+      { id: '16', name: 'responsive-design', merchantID: '1', colourHex: '#000000', description: 'Responsive Design' },
+      { id: '17', name: 'EU-client', merchantID: '1', colourHex: '#000000', description: 'EU Client' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],
@@ -462,9 +462,9 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 1000,
     currency: Currency.EUR,
     tags: [
-      { ID: '18', name: 'logo-design', merchantID: '1', colourHex: '#000000', description: 'Logo Design' },
-      { ID: '19', name: 'branding', merchantID: '1', colourHex: '#000000', description: 'Branding' },
-      { ID: '20', name: 'EU-client', merchantID: '1', colourHex: '#000000', description: 'EU Client' },
+      { id: '18', name: 'logo-design', merchantID: '1', colourHex: '#000000', description: 'Logo Design' },
+      { id: '19', name: 'branding', merchantID: '1', colourHex: '#000000', description: 'Branding' },
+      { id: '20', name: 'EU-client', merchantID: '1', colourHex: '#000000', description: 'EU Client' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],
@@ -484,9 +484,9 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 3500,
     currency: Currency.GBP,
     tags: [
-      { ID: '21', name: 'UX-design', merchantID: '1', colourHex: '#000000', description: 'UX Design' },
-      { ID: '22', name: 'app-development', merchantID: '1', colourHex: '#000000', description: 'App Development' },
-      { ID: '23', name: 'London-client', merchantID: '1', colourHex: '#000000', description: 'London Client' },
+      { id: '21', name: 'UX-design', merchantID: '1', colourHex: '#000000', description: 'UX Design' },
+      { id: '22', name: 'app-development', merchantID: '1', colourHex: '#000000', description: 'App Development' },
+      { id: '23', name: 'London-client', merchantID: '1', colourHex: '#000000', description: 'London Client' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],
@@ -506,9 +506,9 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 4200,
     currency: Currency.GBP,
     tags: [
-      { ID: '24', name: 'web-design', merchantID: '1', colourHex: '#000000', description: 'Web Design' },
-      { ID: '25', name: 'branding', merchantID: '1', colourHex: '#000000', description: 'Branding' },
-      { ID: '26', name: 'London-client', merchantID: '1', colourHex: '#000000', description: 'London Client' },
+      { id: '24', name: 'web-design', merchantID: '1', colourHex: '#000000', description: 'Web Design' },
+      { id: '25', name: 'branding', merchantID: '1', colourHex: '#000000', description: 'Branding' },
+      { id: '26', name: 'London-client', merchantID: '1', colourHex: '#000000', description: 'London Client' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],
@@ -528,9 +528,9 @@ const fewPaymentRequests: LocalPaymentRequest[] = [
     amount: 2200,
     currency: Currency.EUR,
     tags: [
-      { ID: '27', name: 'UI-design', merchantID: '1', colourHex: '#000000', description: 'UI Design' },
-      { ID: '28', name: 'app-development', merchantID: '1', colourHex: '#000000', description: 'App Development' },
-      { ID: '29', name: 'EU-client', merchantID: '1', colourHex: '#000000', description: 'EU Client' },
+      { id: '27', name: 'UI-design', merchantID: '1', colourHex: '#000000', description: 'UI Design' },
+      { id: '28', name: 'app-development', merchantID: '1', colourHex: '#000000', description: 'App Development' },
+      { id: '29', name: 'EU-client', merchantID: '1', colourHex: '#000000', description: 'EU Client' },
     ],
     addresses: [],
     paymentMethodTypes: [LocalPaymentMethodTypes.Card, LocalPaymentMethodTypes.Pisp],


### PR DESCRIPTION
- Made the payment request details modal functional.
- Getting payment attempts from the api.
- Made the tag manager functional.
- Refund functionality for card will be implemented in subsequent PR.
- Display of processor i.e MasterCard/Visa/Bank name will be done in MOOV-1807.
- Using contentType as json for all API requests now. Have tested it and it works.

- Issues right now - 1. When some payments are in authorized state, the PR status remains as Partially Paid and the amount outstanding is 0. It is confusing as their is not indication that some payments are in authorized state.
2. Cannot add tags after payment is made on the PR because the update PR api does not allow that. Need discussion about this.