### PR TITLE
[MOOV-1816]: Fixed missing key field on loading rows

### DIFF
--- a/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
+++ b/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
@@ -109,8 +109,8 @@ const PaymentRequestTable = ({
               // to display a loading skeleton
               // while the data is being fetched
               // from the server
-              Array.from(Array(12)).map(() => (
-                <tr className="animate-pulse border-b border-[#F1F2F3]">
+              Array.from(Array(12)).map((_, index) => (
+                <tr key={`pr-placeholder-${index}`} className="animate-pulse border-b border-[#F1F2F3]">
                   {/* Status */}
                   <td className="py-6">
                     <div className="w-1/2 ml-4 h-2 bg-[#E0E9EB] rounded-lg" />


### PR DESCRIPTION
When displaying the Payment Request table, the console would print an error indicating that elements in a list should have a unique `key` field. This was due to the addition of the loading indicator rows.

Added a unique `key` field to those.