### PR TITLE
[MOOV-1808]: Enabled payment request table reload on add and delete

### DIFF
--- a/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -1,7 +1,7 @@
 import { PaymentRequestStatus } from '../../../api/types/Enums';
 import Tab from '../../ui/Tab/Tab';
 import * as Tabs from '@radix-ui/react-tabs';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import DateRangePicker, { DateRange } from '../../ui/DateRangePicker/DateRangePicker';
 import PrimaryButton from '../../ui/PrimaryButton/PrimaryButton';
 import { usePaymentRequestMetrics } from '../../../api/hooks/usePaymentRequestMetrics';
@@ -66,8 +66,7 @@ const PaymentRequestDashboard = ({
     status,
   );
 
-  const localPaymentRequests: LocalPaymentRequest[] =
-    paymentRequests?.map((paymentRequest) => RemotePaymentRequestToLocalPaymentRequest(paymentRequest)) ?? [];
+  const [localPaymentRequests, setLocalPaymentRequests] = useState<LocalPaymentRequest[]>([]);
 
   const [firstMetrics, setFirstMetrics] = useState<PaymentRequestMetrics | undefined>();
 
@@ -78,6 +77,12 @@ const PaymentRequestDashboard = ({
     dateRange.fromDate.getTime(),
     dateRange.toDate.getTime(),
   );
+
+  useEffect(() => {
+    setLocalPaymentRequests(
+      paymentRequests?.map((paymentRequest) => RemotePaymentRequestToLocalPaymentRequest(paymentRequest)) ?? [],
+    );
+  }, [paymentRequests]);
 
   const onDeletePaymentRequest = async (paymentRequest: LocalPaymentRequest) => {
     const response = await client.delete(paymentRequest.id);

--- a/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -28,7 +28,7 @@ import _ from 'lodash';
 interface CreatePaymentRequestPageProps {
   banks: BankSettings[];
   userPaymentDefaults?: UserPaymentDefaults;
-  onConfirm: (data: LocalPaymentRequestCreate) => void;
+  onConfirm: (data: LocalPaymentRequestCreate) => Promise<void>;
   isOpen: boolean;
   onClose: () => void;
   onDefaultsChanged: (data: UserPaymentDefaults) => void;
@@ -133,7 +133,7 @@ const CreatePaymentRequestPage = ({
     setIsReviewing(true);
   };
 
-  const onConfirmClicked = () => {
+  const onConfirmClicked = async () => {
     const paymentRequestToCreate: LocalPaymentRequestCreate = {
       amount: Number(amount),
       currency: currency as Currency,
@@ -159,7 +159,7 @@ const CreatePaymentRequestPage = ({
       },
     };
 
-    onConfirm(paymentRequestToCreate);
+    await onConfirm(paymentRequestToCreate);
 
     if (defaultsChanged) {
       handleDefaultsChanged();


### PR DESCRIPTION
When adding or deleting a payment request from the table, it didn't automatically reload. The culprit was the fact that we were storing the payment request list on a constant.

Changed to a `useState` and changed the `onConfirm` method from `CreatePaymentRequestPage` to a `Promise<void>`, so the code can wait until the request finishes and return the user to the table with newly fetched data.