### PR TITLE
[MOK-137]: Added Azure DevOps CI/CD pipelines

### DIFF
--- a/azure-pipeline-dev.yaml
+++ b/azure-pipeline-dev.yaml
@@ -30,7 +30,7 @@ variables:
 
 # A windows agent is required here as the AzureFileCopy@4 task is windows only.
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'ubuntu-latest'
 
 steps:
   # these steps set the .js bundle names

--- a/azure-pipeline-dev.yaml
+++ b/azure-pipeline-dev.yaml
@@ -1,0 +1,100 @@
+#------------------------------------------------------------------------------
+#
+# Filename: azure-pipeline-dev.yml
+#
+# Description: Deploy react payelement dev storage account with dev/sandbox filenames.
+#
+# Usage:  Run from devops pipeline. Notes:
+#         - Set a variable called 'environment' in the pipeline GUI to specify whether DEV or 
+#           SANDBOX filenames are to be used.
+#         - The version is extracted from the package.json file by npm build and the pipeline copy tasks
+#         - The versioned bundle copy depends on there being a single *.js file in the dist/ directory
+#
+# Author: James Bramich (james@nofrixion.com)
+#
+# History:
+# 15 December 2022  James Bramich   Created, Northdown, Australia
+#  2 March    2023  James Bramich   updated to allow for 'sandbox' deployment
+# 18 May      2023  Axel Granillo   Changed destination to production CDN, "dev" folder
+#-----------------------------------------------------------------------------
+
+pr: none # don't run on PR
+trigger:
+  - develop
+
+variables:
+# Azure service connection for storage account access
+  serviceConnection: "Prod Azure - NoFrixion Ops"
+  storageAccountName: "nofrixioncdn"
+  bundleName: "nofrixion-nextgen.js"
+  cdnRg: "nofrixion-ops"
+  cdnName: "nofrixioncdn"
+  cdnProfileName: "nofrixioncdn"
+
+# A windows agent is required here as the AzureFileCopy@4 task is windows only.
+pool:
+  vmImage: "windows-latest"
+
+steps:
+  # these steps set the .js bundle names
+  - bash: |
+      # get package version from package.json file
+      version=$(cat package.json | jq -r '.version')
+      echo "Version is: $version"
+      echo "##vso[task.setvariable variable=versionedBundleName;]nofrixion-nextgen-v${version}.min.js"
+    displayName: 'set DEV .js bundle names'
+
+  - task: NodeTool@0
+    inputs:
+      versionSpec: "16.x"
+    displayName: "Install Node.js"
+
+  - script: |
+      npm install
+    displayName: "npm install"
+
+  - script: |
+      npm run build --omit=dev -- --env public_path="$(PublicPath)"
+    displayName: "npm build prod"
+
+  - script: |
+      rm dist/js/*.txt
+      mv dist/js/*.js "dist/js/$(versionedBundleName)"
+      cd dist/js
+      mkdir chunks
+      cd ../..
+      mv dist/*.js dist/js/chunks
+    displayName: "Rename bundles and remove license file"
+
+  # Creates folder structure for blob container
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: "$(Build.SourcesDirectory)/dist/js"
+      contents: "**"
+      targetFolder: "$(Build.ArtifactStagingDirectory)/dev"
+    displayName: "Copy js files"
+
+  - script: |
+      echo "Bundle filename is: $(bundleName)"
+      cp dist/payelement/payelement.js  $(Build.ArtifactStagingDirectory)/dev/$(bundleName)
+    displayName: "Copy non-versioned bundle to staging dir"
+
+  # Copy main .js file to the $web container.
+  - task: AzureFileCopy@4
+    inputs:
+      sourcePath: $(Build.ArtifactStagingDirectory)/dev
+      azureSubscription: $(serviceConnection)
+      destination: azureBlob
+      storage: "$(storageAccountName)"
+      containerName: "$web"
+    displayName: "Copy dev bundle into $web blob container"
+
+# Purge CDN endpoint to remove old version
+  - task: AzureCLI@2
+    displayName: Purge CDN endpoint
+    inputs:
+      azureSubscription: $(serviceConnection)
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        az cdn endpoint purge -g "$(cdnRg)" -n "$(cdnName)" --profile-name "$(cdnProfileName)" --content-paths '/dev/*' '/dev/chunks/*'

--- a/azure-pipeline-dev.yaml
+++ b/azure-pipeline-dev.yaml
@@ -78,7 +78,7 @@ steps:
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload-batch -s "$(Build.ArtifactStagingDirectory)/dev" -d '$web' --account-name "$(storageAccountName)"
+        az storage blob upload-batch -s "$(Build.ArtifactStagingDirectory)" -d '$web' --account-name "$(storageAccountName)"
 
   # Purge CDN endpoint to remove old version
   - task: AzureCLI@2

--- a/azure-pipeline-dev.yaml
+++ b/azure-pipeline-dev.yaml
@@ -71,14 +71,14 @@ steps:
     displayName: 'Copy js files'
 
   # Copy main .js file to the $web container.
-  - task: AzureFileCopy@4
+  - task: AzureCLI@2
+    displayName: Copy dev bundle into $web blob container
     inputs:
-      sourcePath: $(Build.ArtifactStagingDirectory)/dev
       azureSubscription: $(serviceConnection)
-      destination: azureBlob
-      storage: '$(storageAccountName)'
-      containerName: '$web'
-    displayName: 'Copy dev bundle into $web blob container'
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        az storage blob upload-batch -s "$(Build.ArtifactStagingDirectory)/dev" -d '$web' --account-name "$(storageAccountName)"
 
   # Purge CDN endpoint to remove old version
   - task: AzureCLI@2

--- a/azure-pipeline-dev.yaml
+++ b/azure-pipeline-dev.yaml
@@ -1,21 +1,18 @@
+---
 #------------------------------------------------------------------------------
 #
 # Filename: azure-pipeline-dev.yml
 #
-# Description: Deploy react payelement dev storage account with dev/sandbox filenames.
+# Description: Deploy web components to DEV path on PROD CDN.
 #
 # Usage:  Run from devops pipeline. Notes:
-#         - Set a variable called 'environment' in the pipeline GUI to specify whether DEV or 
-#           SANDBOX filenames are to be used.
 #         - The version is extracted from the package.json file by npm build and the pipeline copy tasks
 #         - The versioned bundle copy depends on there being a single *.js file in the dist/ directory
 #
 # Author: James Bramich (james@nofrixion.com)
 #
 # History:
-# 15 December 2022  James Bramich   Created, Northdown, Australia
-#  2 March    2023  James Bramich   updated to allow for 'sandbox' deployment
-# 18 May      2023  Axel Granillo   Changed destination to production CDN, "dev" folder
+# 20 June     2023  Axel Granillo   Created, Mexico City, Mexico
 #-----------------------------------------------------------------------------
 
 pr: none # don't run on PR
@@ -23,17 +20,17 @@ trigger:
   - develop
 
 variables:
-# Azure service connection for storage account access
-  serviceConnection: "Prod Azure - NoFrixion Ops"
-  storageAccountName: "nofrixioncdn"
-  bundleName: "nofrixion-nextgen.js"
-  cdnRg: "nofrixion-ops"
-  cdnName: "nofrixioncdn"
-  cdnProfileName: "nofrixioncdn"
+  # Azure service connection for storage account access
+  serviceConnection: 'Prod Azure - NoFrixion Ops'
+  storageAccountName: 'nofrixioncdn'
+  bundleName: 'nofrixion-webcomponents.js'
+  cdnRg: 'nofrixion-ops'
+  cdnName: 'nofrixioncdn'
+  cdnProfileName: 'nofrixioncdn'
 
 # A windows agent is required here as the AzureFileCopy@4 task is windows only.
 pool:
-  vmImage: "windows-latest"
+  vmImage: 'windows-latest'
 
 steps:
   # these steps set the .js bundle names
@@ -41,43 +38,37 @@ steps:
       # get package version from package.json file
       version=$(cat package.json | jq -r '.version')
       echo "Version is: $version"
-      echo "##vso[task.setvariable variable=versionedBundleName;]nofrixion-nextgen-v${version}.min.js"
+      echo "##vso[task.setvariable variable=versionedBundleName;]nofrixion-webcomponents-v${version}.min.js"
     displayName: 'set DEV .js bundle names'
 
   - task: NodeTool@0
     inputs:
-      versionSpec: "16.x"
-    displayName: "Install Node.js"
+      versionSpec: '16.x'
+    displayName: 'Install Node.js'
 
   - script: |
       npm install
-    displayName: "npm install"
+    displayName: 'npm install'
 
   - script: |
-      npm run build --omit=dev -- --env public_path="$(PublicPath)"
-    displayName: "npm build prod"
+      npm run build
+    displayName: 'npm build prod'
 
   - script: |
-      rm dist/js/*.txt
-      mv dist/js/*.js "dist/js/$(versionedBundleName)"
-      cd dist/js
-      mkdir chunks
-      cd ../..
-      mv dist/*.js dist/js/chunks
-    displayName: "Rename bundles and remove license file"
+      cd dist
+      mkdir js
+      cd ..
+      cp dist/*.cjs dist/js/$(bundleName)
+      mv dist/*.cjs "dist/js/$(versionedBundleName)"
+    displayName: 'Rename bundles'
 
   # Creates folder structure for blob container
   - task: CopyFiles@2
     inputs:
-      sourceFolder: "$(Build.SourcesDirectory)/dist/js"
-      contents: "**"
-      targetFolder: "$(Build.ArtifactStagingDirectory)/dev"
-    displayName: "Copy js files"
-
-  - script: |
-      echo "Bundle filename is: $(bundleName)"
-      cp dist/payelement/payelement.js  $(Build.ArtifactStagingDirectory)/dev/$(bundleName)
-    displayName: "Copy non-versioned bundle to staging dir"
+      sourceFolder: '$(Build.SourcesDirectory)/dist/js'
+      contents: '**'
+      targetFolder: '$(Build.ArtifactStagingDirectory)/dev'
+    displayName: 'Copy js files'
 
   # Copy main .js file to the $web container.
   - task: AzureFileCopy@4
@@ -85,11 +76,11 @@ steps:
       sourcePath: $(Build.ArtifactStagingDirectory)/dev
       azureSubscription: $(serviceConnection)
       destination: azureBlob
-      storage: "$(storageAccountName)"
-      containerName: "$web"
-    displayName: "Copy dev bundle into $web blob container"
+      storage: '$(storageAccountName)'
+      containerName: '$web'
+    displayName: 'Copy dev bundle into $web blob container'
 
-# Purge CDN endpoint to remove old version
+  # Purge CDN endpoint to remove old version
   - task: AzureCLI@2
     displayName: Purge CDN endpoint
     inputs:
@@ -97,4 +88,4 @@ steps:
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
-        az cdn endpoint purge -g "$(cdnRg)" -n "$(cdnName)" --profile-name "$(cdnProfileName)" --content-paths '/dev/*' '/dev/chunks/*'
+        az cdn endpoint purge -g "$(cdnRg)" -n "$(cdnName)" --profile-name "$(cdnProfileName)" --content-paths '/dev/*'

--- a/azure-pipeline-prod.yaml
+++ b/azure-pipeline-prod.yaml
@@ -1,13 +1,11 @@
 ---
 #------------------------------------------------------------------------------
 #
-# Filename: azure-pipeline-dev.yml
+# Filename: azure-pipeline-prod.yml
 #
-# Description: Deploy web components to DEV path on PROD CDN.
+# Description: Deploy web components to PROD CDN.
 #
-# Usage:  Run from devops pipeline. Notes:
-#         - The version is extracted from the package.json file by npm build and the pipeline copy tasks
-#         - The versioned bundle copy depends on there being a single *.js file in the dist/ directory
+# Usage: run from devops pipeline
 #
 # Author: Axel Granillo (axel@nofrixion.com)
 #
@@ -17,11 +15,11 @@
 
 pr: none # don't run on PR
 trigger:
-  - develop
+  - none
 
 variables:
   # Azure service connection for storage account access
-  serviceConnection: 'Prod Azure - NoFrixion Ops'
+  serviceConnection: 'NoFrixion Production'
   storageAccountName: 'nofrixioncdn'
   bundleName: 'nofrixion-webcomponents.js'
   cdnRg: 'nofrixion-ops'
@@ -33,14 +31,6 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-  # these steps set the .js bundle names
-  - bash: |
-      # get package version from package.json file
-      version=$(cat package.json | jq -r '.version')
-      echo "Version is: $version"
-      echo "##vso[task.setvariable variable=versionedBundleName;]nofrixion-webcomponents-v${version}.min.js"
-    displayName: 'set DEV .js bundle names'
-
   - task: NodeTool@0
     inputs:
       versionSpec: '16.x'
@@ -58,21 +48,21 @@ steps:
       cd dist
       mkdir js
       cd ..
-      cp dist/*.cjs dist/js/$(bundleName)
-      mv dist/*.cjs "dist/js/$(versionedBundleName)"
+      cp dist/*.cjs "dist/js/$(versionedBundleName)"
+      mv dist/*.cjs dist/$(bundleName)
     displayName: 'Rename bundles'
 
   # Creates folder structure for blob container
   - task: CopyFiles@2
     inputs:
-      sourceFolder: '$(Build.SourcesDirectory)/dist/js'
+      sourceFolder: '$(Build.SourcesDirectory)/dist'
       contents: '**'
-      targetFolder: '$(Build.ArtifactStagingDirectory)/dev'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
     displayName: 'Copy js files'
 
-  # Copy main .js file to the $web container.
+  # Copy .js files to the $web container.
   - task: AzureCLI@2
-    displayName: Copy dev bundle into $web blob container
+    displayName: Copy bundle into $web blob container
     inputs:
       azureSubscription: $(serviceConnection)
       scriptType: pscore
@@ -88,4 +78,4 @@ steps:
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
-        az cdn endpoint purge -g "$(cdnRg)" -n "$(cdnName)" --profile-name "$(cdnProfileName)" --content-paths '/dev/*'
+        az cdn endpoint purge -g "$(cdnRg)" -n "$(cdnName)" --profile-name "$(cdnProfileName)" --content-paths '/$(bundleName)'

--- a/azure-pipeline-prod.yaml
+++ b/azure-pipeline-prod.yaml
@@ -31,6 +31,14 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
+  # these steps set the .js bundle names
+  - bash: |
+      # get package version from package.json file
+      version=$(cat package.json | jq -r '.version')
+      echo "Version is: $version"
+      echo "##vso[task.setvariable variable=versionedBundleName;]nofrixion-webcomponents-v${version}.min.js"
+    displayName: 'set PROD .js bundle names'
+
   - task: NodeTool@0
     inputs:
       versionSpec: '16.x'


### PR DESCRIPTION
Added Azure DevOps DEV and PROD CI/CD pipelines. These pipelines deploy the generated *.cjs file as *.js files to the PROD CDN, with the following URLs:

|  | DEV | PROD |
| ------------- | ------------- | ------------- |
| Non-versioned bundle | https://cdn.nofrixion.com/dev/nofrixion-webcomponents.js | https://cdn.nofrixion.com/nofrixion-webcomponents.js |
| Versioned bundle | https://cdn.nofrixion.com/dev/nofrixion-webcomponents-vX.X.X.min.js | https://cdn.nofrixion.com/js/nofrixion-webcomponents-vX.X.X.min.js |

Might need to include these URLs in the MoneyMoov Portal CI/CD pipelines.