### PR TITLE
[MOOV-1967] Added PR metrics refresh on filter, create and delete

### DIFF
--- a/src/api/clients/PaymentRequestClient.ts
+++ b/src/api/clients/PaymentRequestClient.ts
@@ -39,6 +39,11 @@ export class PaymentRequestClient extends BaseApiClient {
    * @param fromDate Optional. The date filter to apply to retrieve payment requests created after this date.
    * @param toDate Optional. The date filter to apply to retrieve payment requests created up until this date.
    * @param status Optional. The status filter to apply to retrieve records with this status.
+   * @param search Optional. The search filter to apply to retrieve records with this search text in the description, title, merchant name or contact name.
+   * @param currency Optional. The currency filter to apply to retrieve records with this currency.
+   * @param minAmount Optional. The minimum amount filter to apply to retrieve records with this minimum amount.
+   * @param maxAmount Optional. The maximum amount filter to apply to retrieve records with this maximum amount.
+   * @param tags Optional. The tags filter to apply to retrieve records with these tags.
    * @returns A PaymentRequestPageResponse if successful. An ApiError if not successful.
    */
   async getAll(
@@ -183,11 +188,21 @@ export class PaymentRequestClient extends BaseApiClient {
    * Gets the metrics for Payment Requests
    * @param fromDate Optional. The date filter to apply to retrieve payment requests metrics after this date.
    * @param toDate Optional. The date filter to apply to retrieve payment requests metrics up until this date.
+   * @param search Optional. The search filter to apply to retrieve payment request metrics with this search text in the description, title, merchant name or contact name.
+   * @param currency Optional. The currency filter to apply to retrieve payment request metrics with this currency.
+   * @param minAmount Optional. The minimum amount filter to apply to retrieve payment request metrics with this minimum amount.
+   * @param maxAmount Optional. The maximum amount filter to apply to retrieve payment request metrics with this maximum amount.
+   * @param tags Optional. The tags filter to apply to retrieve payment request metrics with these tags.
    * @returns A PaymentRequestMetrics response if successful. An ApiError if not successful.
    */
   async metrics(
     fromDate?: Date,
     toDate?: Date,
+    search?: string,
+    currency?: string,
+    minAmount?: number,
+    maxAmount?: number,
+    tags?: string[],
   ): Promise<{
     data?: PaymentRequestMetrics;
     error?: ApiError;
@@ -204,6 +219,26 @@ export class PaymentRequestClient extends BaseApiClient {
 
     if (toDate) {
       filterParams.append('toDate', toDate.toUTCString());
+    }
+
+    if (search) {
+      filterParams.append('search', search);
+    }
+
+    if (currency) {
+      filterParams.append('currency', currency);
+    }
+
+    if (minAmount) {
+      filterParams.append('minAmount', minAmount.toString());
+    }
+
+    if (maxAmount) {
+      filterParams.append('maxAmount', maxAmount.toString());
+    }
+
+    if (tags) {
+      tags.forEach((tag) => filterParams.append('tags', tag));
     }
 
     url = `${url}?${filterParams.toString()}`;

--- a/src/api/hooks/usePaymentRequestMetrics.ts
+++ b/src/api/hooks/usePaymentRequestMetrics.ts
@@ -9,31 +9,45 @@ export const usePaymentRequestMetrics = (
   onUnauthorized: () => void,
   fromDateMs?: number,
   toDateMs?: number,
+  searchFilter?: string,
+  currency?: string,
+  minAmount?: number,
+  maxAmount?: number,
+  tags?: string[],
 ) => {
   const [metrics, setMetrics] = useState<PaymentRequestMetrics>();
   const [apiError, setApiError] = useState<ApiError>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
+  const fetchPaymentRequestMetrics = async () => {
+    setIsLoading(true);
+    const client = new PaymentRequestClient(apiUrl, authToken, merchantId, onUnauthorized);
+    const response = await client.metrics(
+      new Date(fromDateMs ?? 0),
+      new Date(toDateMs ?? 0),
+      searchFilter,
+      currency,
+      minAmount,
+      maxAmount,
+      tags,
+    );
+
+    if (response.data) {
+      setMetrics(response.data);
+    } else if (response.error) {
+      setApiError(response.error);
+    }
+    setIsLoading(false);
+  };
+
   useEffect(() => {
-    const fetchPaymentRequestMetrics = async () => {
-      setIsLoading(true);
-      const client = new PaymentRequestClient(apiUrl, authToken, merchantId, onUnauthorized);
-      const response = await client.metrics(new Date(fromDateMs ?? 0), new Date(toDateMs ?? 0));
-
-      if (response.data) {
-        setMetrics(response.data);
-      } else if (response.error) {
-        setApiError(response.error);
-      }
-      setIsLoading(false);
-    };
-
     fetchPaymentRequestMetrics();
-  }, [apiUrl, authToken, merchantId, fromDateMs, toDateMs]);
+  }, [apiUrl, authToken, merchantId, fromDateMs, toDateMs, searchFilter, currency, minAmount, maxAmount, tags]);
 
   return {
     metrics,
     apiError,
     isLoading,
+    fetchPaymentRequestMetrics,
   };
 };

--- a/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -106,13 +106,22 @@ const PaymentRequestDashboard = ({
 
   const [firstMetrics, setFirstMetrics] = useState<PaymentRequestMetrics | undefined>();
 
-  const { metrics, isLoading: isLoadingMetrics } = usePaymentRequestMetrics(
+  const {
+    metrics,
+    isLoading: isLoadingMetrics,
+    fetchPaymentRequestMetrics,
+  } = usePaymentRequestMetrics(
     apiUrl,
     token,
     merchantId,
     onUnauthorized,
     dateRange.fromDate.getTime(),
     dateRange.toDate.getTime(),
+    searchFilter?.length >= 3 ? searchFilter : undefined,
+    currencyFilter,
+    minAmountFilter,
+    maxAmountFilter,
+    tagsFilter,
   );
 
   const merchantTags = useMerchantTags(apiUrl, token, merchantId, onUnauthorized);
@@ -160,7 +169,8 @@ const PaymentRequestDashboard = ({
 
     makeToast('success', 'Payment request successfully deleted.');
 
-    await fetchPaymentRequests();
+    fetchPaymentRequests();
+    fetchPaymentRequestMetrics();
   };
 
   const onCopyPaymentRequestLink = async (paymentRequest: LocalPaymentRequest) => {
@@ -193,19 +203,21 @@ const PaymentRequestDashboard = ({
 
     // Refresh the payment requests table
     // TODO: Table is not refreshing
-    await fetchPaymentRequests();
+    fetchPaymentRequests();
+    fetchPaymentRequestMetrics();
   };
 
   // tore the results of the first execution of the metrics
   // and use them as the initial state of the metrics.
   // This way, when they change the dates
   // we don't see the metrics disappear
-  if (metrics && !firstMetrics) {
-    setFirstMetrics(metrics);
-  }
+  useEffect(() => {
+    if (metrics && (!firstMetrics || firstMetrics?.all === 0)) {
+      setFirstMetrics(metrics);
+    }
+  }, [metrics]);
 
   const isInitialState = !isLoadingMetrics && (!firstMetrics || firstMetrics?.all === 0);
-
   return (
     <div className="font-inter bg-mainGrey text-defaultText h-full pl-8 pr-8 pb-10">
       <div className="flex justify-between">


### PR DESCRIPTION
When applying filters, the Payment Request Metrics weren't updating, causing a mismatch between what was shown in the table and the status tabs.

Also, fixed an issue where upon creating the first payment request for a new merchant, the empty state remained visible.