### PR TITLE
[MOOV-1985]: PR Details now shows title even w/o description

### DIFF
--- a/src/components/ui/PaymentRequestDetails/PaymentRequestDetails.tsx
+++ b/src/components/ui/PaymentRequestDetails/PaymentRequestDetails.tsx
@@ -51,7 +51,7 @@ const PaymentRequestDetails = ({
           </div>
         </div>
         <div className="mb-[2.625rem]">
-          {paymentRequest.productOrService && paymentRequest.description && (
+          {(paymentRequest.productOrService || paymentRequest.description) && (
             <div className="flex flex-col gap-2 lg:gap-4 mb-6 lg:mb-8">
               {paymentRequest.productOrService && (
                 <span className="text-base leading-[1.188rem] font-medium">{paymentRequest.productOrService}</span>


### PR DESCRIPTION
Payment Request Details modal now displays the title even if the payment request doesn't have a description.

![image](https://github.com/nofrixion/nofrixion.webcomponents/assets/114026805/36934709-dac6-4648-8195-437e5dec7584)
