### PR TITLE
[MOOV-1989]: Wallet payment defaults is now part of Cards

### DIFF
--- a/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -398,7 +398,10 @@ const CreatePaymentRequestPage = ({
             <div className="flex items-center space-x-3">
               <PaymentMethodIcon paymentMethod="bank" enabled={paymentMethodsFormValue.isBankEnabled} />
               <PaymentMethodIcon paymentMethod="card" enabled={paymentMethodsFormValue.isCardEnabled} />
-              <PaymentMethodIcon paymentMethod="wallet" enabled={paymentMethodsFormValue.isWalletEnabled} />
+              <PaymentMethodIcon
+                paymentMethod="wallet"
+                enabled={paymentMethodsFormValue.isCardEnabled && paymentMethodsFormValue.isWalletEnabled}
+              />
               <PaymentMethodIcon paymentMethod="lightning" enabled={paymentMethodsFormValue.isLightningEnabled} />
             </div>
 
@@ -720,7 +723,10 @@ const CreatePaymentRequestPage = ({
                                       <PaymentMethodIcon
                                         showInfoTooltip={false}
                                         paymentMethod="wallet"
-                                        enabled={paymentMethodsFormValue.isWalletEnabled}
+                                        enabled={
+                                          paymentMethodsFormValue.isCardEnabled &&
+                                          paymentMethodsFormValue.isWalletEnabled
+                                        }
                                       />
                                       <PaymentMethodIcon
                                         showInfoTooltip={false}

--- a/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
+++ b/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
@@ -182,7 +182,13 @@ const PaymentMethodsModal = ({
           <AnimatePresence initial={false}>
             {isCardEnabled && (
               <AnimateHeightWrapper layoutId="card-capture-founds">
-                <div className="ml-10 pt-7 md:pb-4">
+                <div className="ml-10 pt-7 md:pb-4 flex flex-col space-y-4">
+                  <Checkbox
+                    label="Enable Apple Pay / Google Pay"
+                    infoText="Enable this option to allow users to pay with Apple Pay or Google Pay."
+                    value={isWalletEnabled}
+                    onChange={setIsWalletEnabled}
+                  />
                   <Checkbox
                     label="Don't capture funds on card payments"
                     infoText="Enable this option to authorize card payments without immediately capturing the funds. This allows for manual capture or cancellation before completing the transaction."
@@ -194,13 +200,6 @@ const PaymentMethodsModal = ({
             )}
           </AnimatePresence>
         </div>
-        <Switch
-          icon={ApplePayIcon}
-          label="Apple Pay / Google Pay"
-          value={isWalletEnabled}
-          onChange={setIsWalletEnabled}
-          className="py-6 md:py-4"
-        />
         <Switch
           icon={BitcoinIcon}
           label="Bitcoin Lightning"

--- a/src/components/ui/PaymentInfo/PaymentInfo.tsx
+++ b/src/components/ui/PaymentInfo/PaymentInfo.tsx
@@ -56,7 +56,7 @@ const PaymentInfo = ({ id, createdAt, paymentMethodTypes, addresses }: PaymentIn
         <div className="space-x-3">
           <PaymentMethodIcon paymentMethod="bank" enabled={isBankEnabled} />
           <PaymentMethodIcon paymentMethod="card" enabled={isCardEnabled} />
-          <PaymentMethodIcon paymentMethod="wallet" enabled={isWalletEnabled} />
+          <PaymentMethodIcon paymentMethod="wallet" enabled={isCardEnabled && isWalletEnabled} />
           <PaymentMethodIcon paymentMethod="lightning" enabled={isLightningEnabled} />
         </div>
       </PaymentInfoRow>


### PR DESCRIPTION
Wallet payment method has been moved under Card payment. Visuals and logic have been adjusted to reflect so.

Note: 
There are some bugs regarding the "Use as my default" checkbox. Those bugs have been fixed in #99 but are still waiting to be approved and merged.

Also, there's a corresponding API PR awaiting approval.