### PR TITLE
[MOOV-1989]: Added warning when only enabling wallet payments

### DIFF
--- a/src/components/ui/CustomModal/CustomModal.tsx
+++ b/src/components/ui/CustomModal/CustomModal.tsx
@@ -3,12 +3,14 @@ import { Dialog, Transition } from '@headlessui/react';
 import Checkbox from '../Checkbox/Checkbox';
 import { Button } from '@/components/ui/atoms';
 import { AnimatePresence, motion } from 'framer-motion';
+import classNames from 'classnames';
 
 interface CustomModalProps extends BaseModalProps {
   title: string;
   enableUseAsDefault?: boolean;
   children: React.ReactNode;
   onApplyEnabled?: boolean;
+  buttonRowClassName?: string;
 }
 
 export interface BaseModalProps {
@@ -29,6 +31,7 @@ const CustomModal = ({
   onApply,
   onDismiss,
   onApplyEnabled = true,
+  buttonRowClassName,
 }: CustomModalProps) => {
   const [isDefaultChecked, setIsDefaultChecked] = useState<boolean>(false);
   const [currentState, setCurrentState] = useState<CustomModalState>();
@@ -104,7 +107,12 @@ const CustomModal = ({
                 </Dialog.Title>
                 <div className="px-6 md:px-12">{children}</div>
 
-                <div className="bg-mainGrey flex flex-col-reverse items-center gap-4 md:gap-0 md:flex-row md:justify-between px-6 md:pl-8 md:pr-6 py-4 mt-4 md:mt-12">
+                <div
+                  className={classNames(
+                    buttonRowClassName,
+                    'bg-mainGrey flex flex-col-reverse items-center gap-4 md:gap-0 md:flex-row md:justify-between px-6 md:pl-8 md:pr-6 py-4 mt-4 md:mt-12',
+                  )}
+                >
                   <div>
                     <AnimatePresence>
                       {enableUseAsDefault && (

--- a/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
+++ b/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
@@ -237,8 +237,8 @@ const PaymentMethodsModal = ({
           <AnimateHeightWrapper layoutId="wallet-card-alert">
             <div className="w-full p-3 mt-6 bg-[#FCF5CF] rounded">
               <p className="text-sm text-default-text font-normal">
-                If you only enable mobile wallets, make sure your customer has Apple Pay or Google Pay available. If you
-                are not sure, include another payment method.
+                Do your customers have access to Apple Pay or Google Pay? If you are unsure, you may want to consider
+                adding a second payment method as a backup.
               </p>
             </div>
           </AnimateHeightWrapper>

--- a/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
+++ b/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
@@ -147,9 +147,17 @@ const PaymentMethodsModal = ({
       enableUseAsDefault={enableUseAsDefault}
       onDismiss={handleOnDismiss}
       onApply={onApplyClicked}
+      buttonRowClassName={isWalletEnabled && !isCardEnabled && !isBankEnabled && !isLightningEnabled ? 'md:mt-6' : ''}
     >
-      <div className="divide-y">
-        <div className="pb-6 md:pb-4">
+      <div className="[&>*]:border-b [&>*]:border-solid [&>*]:border-b-borderGrey">
+        <Switch
+          icon={ApplePayIcon}
+          label="Apple Pay / Google Pay"
+          value={isWalletEnabled}
+          onChange={setIsWalletEnabled}
+          className="pb-6 md:pb-4"
+        />
+        <div className="py-6 md:py-4">
           <Switch icon={BankIcon} label="Pay by Bank" value={isBankEnabled} onChange={setIsBankEnabled} />
 
           <AnimatePresence initial={false}>
@@ -216,20 +224,26 @@ const PaymentMethodsModal = ({
           </AnimatePresence>
         </div>
         <Switch
-          icon={ApplePayIcon}
-          label="Apple Pay / Google Pay"
-          value={isWalletEnabled}
-          onChange={setIsWalletEnabled}
-          className="py-6 md:py-4"
-        />
-        <Switch
           icon={BitcoinIcon}
           label="Bitcoin Lightning"
           value={isLightningEnabled}
           onChange={setIsLightningEnabled}
-          className="pt-6 md:pt-4"
+          className="py-6 md:py-4"
         />
       </div>
+
+      <AnimatePresence initial={false}>
+        {isWalletEnabled && !isCardEnabled && !isBankEnabled && !isLightningEnabled && (
+          <AnimateHeightWrapper layoutId="wallet-card-alert">
+            <div className="w-full p-3 mt-6 bg-[#FCF5CF] rounded">
+              <p className="text-sm text-default-text font-normal">
+                If you only enable mobile wallets, make sure your customer has Apple Pay or Google Pay available. If you
+                are not sure, include another payment method.
+              </p>
+            </div>
+          </AnimateHeightWrapper>
+        )}
+      </AnimatePresence>
     </CustomModal>
   );
 };


### PR DESCRIPTION
When creating a payment request, if the user only enables Apple Pay / Google Pay, a warning telling them to make sure their users are able to use those platforms is shown under the payment methods.